### PR TITLE
Add basic CI infrastucture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,14 @@ jobs:
           - os: ubuntu-24.04
             llvm: 20
             python: "3.12"
+            cxx_standard: 17
           - os: ubuntu-24.04
             llvm: 21
             python: "3.14"
+            cxx_standard: 20
 
     runs-on: ${{ matrix.os }}
-    name: LLVM ${{ matrix.llvm }} / Python ${{ matrix.python }}
+    name: LLVM ${{ matrix.llvm }} / Python ${{ matrix.python }} / C++${{ matrix.cxx_standard }}
     permissions:
       pull-requests: write
 
@@ -36,14 +38,15 @@ jobs:
           echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-${{ matrix.llvm }} main" \
             | sudo tee /etc/apt/sources.list.d/llvm.list
           sudo apt-get update
-          sudo apt-get install -y llvm-${{ matrix.llvm }}-dev libclang-${{ matrix.llvm }}-dev clang-${{ matrix.llvm }} libpolly-${{ matrix.llvm }}-dev
+          sudo apt-get install -y llvm-${{ matrix.llvm }}-dev libclang-${{ matrix.llvm }}-dev clang-${{ matrix.llvm }} libpolly-${{ matrix.llvm }}-dev \
+            libboost-dev libeigen3-dev
 
       - name: Install Python dev headers
         run: sudo apt-get install -y python${{ matrix.python }}-dev || true
 
       - name: pip install CppJIT
         run: |
-          pip install scikit-build-core pytest
+          pip install pytest numba numpy psutil
           pip install . --config-settings=cmake.define.LLVM_DIR=/usr/lib/llvm-${{ matrix.llvm }}/lib/cmake/llvm -v
         env:
           CMAKE_BUILD_PARALLEL_LEVEL: "4"
@@ -54,6 +57,8 @@ jobs:
 
       - name: Run tests
         working-directory: test
+        env:
+          CPPINTEROP_EXTRA_INTERPRETER_ARGS: "-std=c++${{ matrix.cxx_standard }}"
         run: python -m pytest -ra --tb=short -q 2>&1 | tee ../test-output.txt
 
       - name: Post results to PR
@@ -63,4 +68,4 @@ jobs:
         run: |
           summary=$(tail -1 test-output.txt)
           gh pr comment ${{ github.event.pull_request.number }} \
-            --body "**LLVM ${{ matrix.llvm }} / Python ${{ matrix.python }}**: \`${summary}\`"
+            --body "**LLVM ${{ matrix.llvm }} / Python ${{ matrix.python }} / C++${{ matrix.cxx_standard }}**: \`${summary}\`"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: Linux x86_64
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+
+jobs:
+  build-and-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            llvm: 20
+            python: "3.12"
+          - os: ubuntu-24.04
+            llvm: 21
+            python: "3.14"
+
+    runs-on: ${{ matrix.os }}
+    name: LLVM ${{ matrix.llvm }} / Python ${{ matrix.python }}
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install LLVM ${{ matrix.llvm }}
+        run: |
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-${{ matrix.llvm }} main" \
+            | sudo tee /etc/apt/sources.list.d/llvm.list
+          sudo apt-get update
+          sudo apt-get install -y llvm-${{ matrix.llvm }}-dev libclang-${{ matrix.llvm }}-dev clang-${{ matrix.llvm }} libpolly-${{ matrix.llvm }}-dev
+
+      - name: Install Python dev headers
+        run: sudo apt-get install -y python${{ matrix.python }}-dev || true
+
+      - name: pip install CppJIT
+        run: |
+          pip install scikit-build-core pytest
+          pip install . --config-settings=cmake.define.LLVM_DIR=/usr/lib/llvm-${{ matrix.llvm }}/lib/cmake/llvm -v
+        env:
+          CMAKE_BUILD_PARALLEL_LEVEL: "4"
+
+      - name: Build test dictionaries
+        working-directory: test
+        run: make -j4
+
+      - name: Run tests
+        working-directory: test
+        run: python -m pytest -ra --tb=short -q 2>&1 | tee ../test-output.txt
+
+      - name: Post results to PR
+        if: always() && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          summary=$(tail -1 test-output.txt)
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --body "**LLVM ${{ matrix.llvm }} / Python ${{ matrix.python }}**: \`${summary}\`"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,11 +79,46 @@ jobs:
         env:
           CPPINTEROP_EXTRA_INTERPRETER_ARGS: "-std=c++${{ matrix.runtime_cxx_standard }}"
 
-      - name: Post results to PR
-        if: always() && github.event_name == 'pull_request'
-        run: |
-          summary=$(tail -1 test-output.txt)
-          gh pr comment ${{ github.event.pull_request.number }} \
-            --body "**LLVM ${{ matrix.llvm }} / Python ${{ matrix.python }} / C++${{ matrix.runtime_cxx_standard }}**: \`${summary}\`"
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Upload result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: result-${{ matrix.os }}-llvm${{ matrix.llvm }}-py${{ matrix.python }}-cpp${{ matrix.runtime_cxx_standard }}
+          path: test-output.txt
+
+  report:
+    if: always() && github.event_name == 'pull_request'
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: result-*
+
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- cppjit-ci -->';
+
+            const rows = fs.readdirSync('.').filter(d => d.startsWith('result-')).sort().map(d => {
+              const cfg = d.replace('result-', '');
+              const file = `${d}/test-output.txt`;
+              const lines = fs.existsSync(file) ? fs.readFileSync(file, 'utf8').trim().split('\n') : [];
+              const result = lines.length ? lines.at(-1) : 'no output';
+              return `| ${cfg} | \`${result}\` |`;
+            });
+
+            const body = [marker, '## Test Results', '| Configuration | Result |', '|---|---|', ...rows].join('\n');
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo, issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.startsWith(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({ ...context.repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ ...context.repo, issue_number: context.issue.number, body });
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [master, main]
   pull_request:
 
+env:
+  CMAKE_BUILD_PARALLEL_LEVEL: 4
+
 jobs:
   build-and-test:
     strategy:
@@ -14,14 +17,14 @@ jobs:
           - os: ubuntu-24.04
             llvm: 20
             python: "3.12"
-            cxx_standard: 17
+            runtime_cxx_standard: 17
           - os: ubuntu-24.04
             llvm: 21
             python: "3.14"
-            cxx_standard: 20
+            runtime_cxx_standard: 20
 
     runs-on: ${{ matrix.os }}
-    name: LLVM ${{ matrix.llvm }} / Python ${{ matrix.python }} / C++${{ matrix.cxx_standard }}
+    name: LLVM ${{ matrix.llvm }} / Python ${{ matrix.python }} / C++${{ matrix.runtime_cxx_standard }}
     permissions:
       pull-requests: write
 
@@ -38,34 +41,37 @@ jobs:
           echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-${{ matrix.llvm }} main" \
             | sudo tee /etc/apt/sources.list.d/llvm.list
           sudo apt-get update
-          sudo apt-get install -y llvm-${{ matrix.llvm }}-dev libclang-${{ matrix.llvm }}-dev clang-${{ matrix.llvm }} libpolly-${{ matrix.llvm }}-dev \
+          sudo apt-get install -y \
+            llvm-${{ matrix.llvm }}-dev \
+            libclang-${{ matrix.llvm }}-dev \
+            clang-${{ matrix.llvm }} \
+            libpolly-${{ matrix.llvm }}-dev \
             libboost-dev libeigen3-dev
-
-      - name: Install Python dev headers
-        run: sudo apt-get install -y python${{ matrix.python }}-dev || true
+          sudo apt-get install -y python${{ matrix.python }}-dev || true
 
       - name: pip install CppJIT
         run: |
           pip install pytest numba numpy psutil
-          pip install . --config-settings=cmake.define.LLVM_DIR=/usr/lib/llvm-${{ matrix.llvm }}/lib/cmake/llvm -v
+          pip install . -v \
+            --config-settings=cmake.define.LLVM_DIR=/usr/lib/llvm-${{ matrix.llvm }}/lib/cmake/llvm
         env:
           CMAKE_BUILD_PARALLEL_LEVEL: "4"
 
       - name: Build test dictionaries
-        working-directory: test
         run: make -j4
+        working-directory: test
 
       - name: Run tests
+        run: python -m pytest -ra --tb=short -q 2>&1 | tee ../test-output.txt
         working-directory: test
         env:
-          CPPINTEROP_EXTRA_INTERPRETER_ARGS: "-std=c++${{ matrix.cxx_standard }}"
-        run: python -m pytest -ra --tb=short -q 2>&1 | tee ../test-output.txt
+          CPPINTEROP_EXTRA_INTERPRETER_ARGS: "-std=c++${{ matrix.runtime_cxx_standard }}"
 
       - name: Post results to PR
         if: always() && github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           summary=$(tail -1 test-output.txt)
           gh pr comment ${{ github.event.pull_request.number }} \
-            --body "**LLVM ${{ matrix.llvm }} / Python ${{ matrix.python }} / C++${{ matrix.cxx_standard }}**: \`${summary}\`"
+            --body "**LLVM ${{ matrix.llvm }} / Python ${{ matrix.python }} / C++${{ matrix.runtime_cxx_standard }}**: \`${summary}\`"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Linux x86_64
+name: GitHub-hosted
 
 on:
   push:
@@ -20,13 +20,19 @@ jobs:
             runtime_cxx_standard: 17
           - os: ubuntu-24.04
             llvm: 21
+            python: "3.13"
+            runtime_cxx_standard: 20
+          - os: ubuntu-24.04
+            llvm: 21
             python: "3.14"
+            runtime_cxx_standard: 20
+          - os: macos-15
+            llvm: 20
+            python: "3.12"
             runtime_cxx_standard: 20
 
     runs-on: ${{ matrix.os }}
-    name: LLVM ${{ matrix.llvm }} / Python ${{ matrix.python }} / C++${{ matrix.runtime_cxx_standard }}
-    permissions:
-      pull-requests: write
+    name: ${{ matrix.os }} / LLVM ${{ matrix.llvm }} / Py ${{ matrix.python }} / C++${{ matrix.runtime_cxx_standard }}
 
     steps:
       - uses: actions/checkout@v4
@@ -35,7 +41,8 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
-      - name: Install LLVM ${{ matrix.llvm }}
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
         run: |
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg
           echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-${{ matrix.llvm }} main" \
@@ -47,15 +54,20 @@ jobs:
             clang-${{ matrix.llvm }} \
             libpolly-${{ matrix.llvm }}-dev \
             libboost-dev libeigen3-dev
-          sudo apt-get install -y python${{ matrix.python }}-dev || true
+
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: brew install llvm@${{ matrix.llvm }} boost eigen
 
       - name: pip install CppJIT
         run: |
-          pip install pytest numba numpy psutil
-          pip install . -v \
-            --config-settings=cmake.define.LLVM_DIR=/usr/lib/llvm-${{ matrix.llvm }}/lib/cmake/llvm
-        env:
-          CMAKE_BUILD_PARALLEL_LEVEL: "4"
+          pip install pytest numpy psutil
+          pip install numba || true
+          pip install . -v --config-settings=cmake.define.LLVM_DIR=${{
+            runner.os == 'macOS'
+            && format('/opt/homebrew/opt/llvm@{0}/lib/cmake/llvm', matrix.llvm)
+            || format('/usr/lib/llvm-{0}/lib/cmake/llvm', matrix.llvm)
+          }}
 
       - name: Build test dictionaries
         run: make -j4


### PR DESCRIPTION
This sets up a straightforward linux and OS X job that uses system package manager shipped LLVM (20-21) and performs a verbose pip install and runs the test suite. Basic log reporting of the stats as a comment on the PR, that is always updated.