### PR TITLE
[ci] Add Ubuntu arm jobs to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,18 @@ jobs:
             llvm: 21
             python: "3.14"
             runtime_cxx_standard: 20
+          - os: ubuntu-24.04-arm
+            llvm: 20
+            python: "3.12"
+            runtime_cxx_standard: 17
+          - os: ubuntu-24.04-arm
+            llvm: 21
+            python: "3.13"
+            runtime_cxx_standard: 20
+          - os: ubuntu-24.04-arm
+            llvm: 21
+            python: "3.14"
+            runtime_cxx_standard: 20
           - os: macos-15
             llvm: 20
             python: "3.12"


### PR DESCRIPTION
cppyy doesn't have as many tests passing on Ubuntu arm as Ubuntu x86 I believe, so this PR adds Ubuntu arm jobs to the ci.