### PR TITLE
[test] xfail concurrency tests under valgrind on Linux ARM

### DIFF
--- a/test/test_concurrent.py
+++ b/test/test_concurrent.py
@@ -1,5 +1,14 @@
 from pytest import mark, skip
-from support import IS_LINUX_ARM, IS_MAC_ARM, IS_MAC_X86
+from support import IS_LINUX_ARM, IS_MAC_ARM, IS_MAC_X86, IS_VALGRIND
+
+# valgrind < 3.26 cannot decode the LDAPRB (FEAT_LRCPC) instructions the JIT
+# emits for the threaded tests and SIGILLs the whole process; see
+# https://bugs.kde.org/show_bug.cgi?id=476465
+pytestmark = mark.xfail(
+    condition=IS_VALGRIND and IS_LINUX_ARM,
+    run=False,
+    reason="valgrind < 3.26 SIGILLs on JIT-emitted LDAPRB (FEAT_LRCPC)",
+)
 
 
 class TestCONCURRENT:


### PR DESCRIPTION
There is an issue seen on Valgrind ARM: "unrecognised instruction at 0x35b8702c" on the nightlies.

The LDAPRB instruction (ARMv8.3 FEAT_LRCPC load-acquire byte) is an atomic acquire load. The JIT emits it because the arm runner's CPU supports LRCPC, but valgrind 3.22.0 can't decode it, so valgrind raises SIGILL and kills pytest mid-suite. Memcheck itself reports 0 errors.

This is valgrind bug [476465](https://bugs.kde.org/show_bug.cgi?id=476465), fixed in valgrind 3.26.0 (https://sourceware.org/git/?p=valgrind.git;a=commit;h=41e2f95cf129191555e0048ccbbb392ee0fb155e) but that release is not available on ubuntu24

This PR hence marks the test xfail under valgrind until a newer distro ships the fix.