### PR TITLE
[interop] Resolve libclangCppInterOp relative to libcppjit at runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,10 +95,11 @@ execute_process(
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 if(_python_platlib)
-    set(CPPINTEROP_INSTALL_DIR "${_python_platlib}/cppjit_backend")
+    set(CPPINTEROP_INSTALL_PREFIX "${_python_platlib}")
 else()
-    set(CPPINTEROP_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/cppjit_backend")
+    set(CPPINTEROP_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
 endif()
+set(CPPINTEROP_INSTALL_DIR "${CPPINTEROP_INSTALL_PREFIX}/cppjit_backend")
 
 # Include cmake for CppInterOp config and build using ExternalProject.
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/AddCppInterOp.cmake)
@@ -114,11 +115,12 @@ set(INTEROP_SOURCES
 add_library(cppjit SHARED ${CPYRT_SOURCES} ${INTEROP_SOURCES})
 add_dependencies(cppjit CppInterOp)
 
-# The exact library file the wrapper dlopens and the include dir the
-# interpreter boot requires.
+# The wrapper anchors these relative spellings at its own load location,
+# falling back to the install prefix (see cppinterop_paths()).
 target_compile_definitions(cppjit PRIVATE
-    CPPINTEROP_LIBRARY="${CPPINTEROP_INSTALL_DIR}/lib/libclangCppInterOp${CMAKE_SHARED_LIBRARY_SUFFIX}"
-    CPPINTEROP_INCLUDE_DIR="${CPPINTEROP_INSTALL_DIR}/include"
+    CPPINTEROP_INSTALL_PREFIX="${CPPINTEROP_INSTALL_PREFIX}"
+    CPPINTEROP_LIBRARY="cppjit_backend/lib/libclangCppInterOp${CMAKE_SHARED_LIBRARY_SUFFIX}"
+    CPPINTEROP_INCLUDE_DIR="cppjit_backend/include"
 )
 
 target_include_directories(cppjit PRIVATE

--- a/src/interop/interop_wrapper.cxx
+++ b/src/interop/interop_wrapper.cxx
@@ -23,6 +23,7 @@ using namespace cppjit;
 #include <csignal>
 #include <cstdlib> // for getenv
 #include <cstring>
+#include <filesystem>
 #include <iostream>
 #include <map>
 #include <mutex>
@@ -74,13 +75,37 @@ static inline bool is_integral(std::string& s) {
                        }) == s.end();
 }
 
+struct InterOpPaths {
+  std::string Library;
+  std::string IncludeDir;
+};
+
+// One relative layout, two anchors: prefer CppInterOp next to our own load
+// location so wheels relocate; fall back to the build-time install prefix.
+static InterOpPaths cppinterop_paths() {
+  std::filesystem::path anchor = CPPINTEROP_INSTALL_PREFIX;
+#ifndef _WIN32
+  Dl_info info;
+  if (dladdr((void*)&cppinterop_paths, &info) && info.dli_fname) {
+    const std::filesystem::path here =
+        std::filesystem::path(info.dli_fname).parent_path();
+    std::error_code ec;
+    if (std::filesystem::exists(here / CPPINTEROP_LIBRARY, ec))
+      anchor = here;
+  }
+#endif
+  return {(anchor / CPPINTEROP_LIBRARY).string(),
+          (anchor / CPPINTEROP_INCLUDE_DIR).string()};
+}
+
 class ApplicationStarter {
   interop::TInterp_t Interp;
 
 public:
   ApplicationStarter() {
     std::lock_guard<std::recursive_mutex> Lock(InterOpMutex);
-    if (!Cpp::LoadDispatchAPI(CPPINTEROP_LIBRARY)) {
+    const InterOpPaths Paths = cppinterop_paths();
+    if (!Cpp::LoadDispatchAPI(Paths.Library.c_str())) {
       std::cerr << "[cppjit-backend] Failed to load CppInterOp" << std::endl;
       return;
     }
@@ -123,7 +148,7 @@ public:
       Cpp::Process(s.str().c_str());
     }
 
-    Cpp::AddIncludePath(CPPINTEROP_INCLUDE_DIR);
+    Cpp::AddIncludePath(Paths.IncludeDir.c_str());
     Cpp::LoadLibrary("libstdc++", /* lookup= */ true);
 
     // load frequently used headers


### PR DESCRIPTION
The backend used to locate `libclangCppInterOp` through absolute build-time paths, so a wheel built on one machine could not load on another.

This PR implements the following:
  - Library and headers are resolved relative to libcppjit's own load location, with the build-time install prefix as the fallback for build trees. This is necessary for the wheels building infrastructure (#22).
  
Validation: 
- full test suite passes locally across different cxx standard builds
- wheel relocatability: a wheel built in an isolated environment installs and runs in a second fresh venv after the build environment is deleted
- the install-prefix fallback verified against a bare build-directory `libcppjit.so`
- Ran clang-format-18