### PR TITLE
Load CppInterOp explicitly instead of from a global constructor

### DIFF
--- a/python/cppjit/_cpython_cppjit.py
+++ b/python/cppjit/_cpython_cppjit.py
@@ -1,6 +1,7 @@
 """CPython-specific touch-ups"""
 
 import ctypes
+import importlib.util
 
 from . import _stdcpp_fix  # noqa: F401
 
@@ -16,13 +17,17 @@ __all__ = [
     "_end_capture_stderr",
 ]
 
-# the merged libcppjit extension is the backend: importing it loads the
-# C++ runtime (no separate loader.load_cpp_backend() step, which would
-# initialize the interpreter twice)
-import libcppjit as _backend
+# preload the merged extension with ctypes and run LoadCppInterOp() first,
+# so the interpreter is ready before the extension module initializes
+_spec = importlib.util.find_spec("libcppjit")
+if _spec is None or not _spec.origin:
+    raise ImportError("cannot locate the libcppjit extension module")
+_w = ctypes.CDLL(_spec.origin, ctypes.RTLD_GLOBAL)
+if not _w.LoadCppInterOp():
+    raise RuntimeError("failed to load CppInterOp (LoadCppInterOp returned 0)")
+del _spec
 
-# explicitly expose APIs from libcppjit
-_w = ctypes.CDLL(_backend.__file__, ctypes.RTLD_GLOBAL)
+import libcppjit as _backend  # noqa: E402
 
 
 ### template support ---------------------------------------------------------

--- a/src/interop/interop_wrapper.cxx
+++ b/src/interop/interop_wrapper.cxx
@@ -98,11 +98,20 @@ static InterOpPaths cppinterop_paths() {
           (anchor / CPPINTEROP_INCLUDE_DIR).string()};
 }
 
-class ApplicationStarter {
-  interop::TInterp_t Interp;
+} // unnamed namespace
 
-public:
-  ApplicationStarter() {
+// Load CppInterOp and set up the interpreter. A dlopen during static
+// initialization is unsafe, so _cpython_cppjit.py calls this explicitly
+// before the first libcppjit use. Thread-safe and idempotent; returns 1 on
+// success.
+extern "C" {
+RPY_EXPORTED int LoadCppInterOp();
+}
+
+extern "C" int LoadCppInterOp() {
+  static std::once_flag Once;
+  static int Loaded = 0;
+  std::call_once(Once, [] {
     std::lock_guard<std::recursive_mutex> Lock(InterOpMutex);
     const InterOpPaths Paths = cppinterop_paths();
     if (!Cpp::LoadDispatchAPI(Paths.Library.c_str())) {
@@ -111,17 +120,14 @@ public:
     }
     // Check if somebody already loaded CppInterOp and created an
     // interpreter for us.
-    if (auto existingInterp = Cpp::GetInterpreter()) {
-      Interp = existingInterp;
-    } else {
+    if (!Cpp::GetInterpreter()) {
       // CppInterOp itself appends CPPINTEROP_EXTRA_INTERPRETER_ARGS inside
       // CreateInterpreter, so nothing needs to be forwarded from here.
 #if defined(__arm64__) && defined(__APPLE__)
       // If on apple silicon don't use -march=native
-      Interp = Cpp::CreateInterpreter({"-std=c++17"}, /*GpuArgs=*/{});
+      Cpp::CreateInterpreter({"-std=c++17"}, /*GpuArgs=*/{});
 #else
-      Interp = Cpp::CreateInterpreter({"-std=c++17", "-march=native"},
-                                      /*GpuArgs=*/{});
+      Cpp::CreateInterpreter({"-std=c++17", "-march=native"}, /*GpuArgs=*/{});
 #endif
     }
 
@@ -191,10 +197,11 @@ public:
     // helper for multiple inheritance
     Cpp::Declare("namespace __cppjit_internal { struct Sep; }",
                  /*silent=*/false);
-  }
-} _applicationStarter;
 
-} // unnamed namespace
+    Loaded = 1;
+  });
+  return Loaded;
+}
 
 // local helpers -------------------------------------------------------------
 static inline char* cppstring_to_cstring(const std::string& cppstr) {


### PR DESCRIPTION
The backend used to dlopen `libclangCppInterOp` from a global constructor, which runs inside the dlopen of `libcppjit` itself when Python loads the extension. The nested `dlopen` re-enters the loader on partially consistent state, runs the inner library's initializers with no ordering guarantees, and holds the loader lock through the entire interpreter and JIT setup, deadlocking any other thread that touches the loader (as reported by @Vipul-Cariappa). The constructor also had no error channel: on failure it printed and left a half-initialized library.

CppInterOp loading and interpreter setup now run in an exported, idempotent `LoadCppInterOp()` that _cpython_cppjit.py calls before the extension module import. This returns a status that turns into a proper exception on the Python side. The `ApplicationStarter` global is dropped in favor of a clean set of statics, all called by `LoadCppInterOp()`.