### PR TITLE
[TEMP] Run only the nightly arm valgrind cell for iteration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,20 +18,14 @@ jobs:
     name: ${{ matrix.os }}/llvm${{ matrix.llvm }}/py${{ matrix.py }}/c++${{ matrix.cxx }}${{ matrix.vg && '/vg' || '' }}${{ matrix.flavor == 'cling' && '/cling' || '' }}
     strategy:
       fail-fast: false
-      # Mirrors CppInterOp's cppyy PR cells: clang-repl on the same OS/arch/LLVM
-      # /valgrind combos at Python 3.14, plus a cling cell and a C++23 cell
-      # (test_cpp23features runs only there). Breadth (3.12/3.13, C++17, LLVM
-      # 20, arm) lives in nightly.
+      # Iteration scaffold, not for merge: run the nightly arm valgrind
+      # cell (deterministic SIGILL, issue #9) plus one x86 valgrind cell
+      # on every push.
       matrix:
         include:
-          - { os: ubuntu-24.04,   llvm: '21', flavor: system, py: '3.14', cxx: '20', vg: true }
-          - { os: ubuntu-24.04,   llvm: '22', flavor: '',     py: '3.14', cxx: '20' }
-          - { os: ubuntu-24.04,   llvm: '22', flavor: '',     py: '3.14', cxx: '23' }
-          - { os: macos-26,       llvm: '21', flavor: system, py: '3.14', cxx: '20' }
-          - { os: macos-26-intel, llvm: '21', flavor: system, py: '3.14', cxx: '20' }
-          # cling backend, against the cached llvm-root (cling-llvm22) recipe cell.
-          - { os: ubuntu-24.04,   llvm: '22', flavor: cling,  flavor_version: cling-llvm22, py: '3.14', cxx: '20' }
-    uses: compiler-research/ci-workflows/.github/workflows/cppjit.yml@main
+          - { os: ubuntu-24.04-arm, llvm: '22', flavor: '',     py: '3.13', cxx: '20', vg: true }
+          - { os: ubuntu-24.04,     llvm: '21', flavor: system, py: '3.14', cxx: '20', vg: true }
+    uses: compiler-research/ci-workflows/.github/workflows/cppjit.yml@conda-valgrind
     with:
       # CppInterOp is pinned in CppJIT's cmake to a commit compatible
       # with the current forks.

--- a/test/test_concurrent.py
+++ b/test/test_concurrent.py
@@ -1,14 +1,5 @@
 from pytest import mark, skip
-from support import IS_LINUX_ARM, IS_MAC_ARM, IS_MAC_X86, IS_VALGRIND
-
-# valgrind < 3.26 cannot decode the LDAPRB (FEAT_LRCPC) instructions the JIT
-# emits for the threaded tests and SIGILLs the whole process; see
-# https://bugs.kde.org/show_bug.cgi?id=476465
-pytestmark = mark.xfail(
-    condition=IS_VALGRIND and IS_LINUX_ARM,
-    run=False,
-    reason="valgrind < 3.26 SIGILLs on JIT-emitted LDAPRB (FEAT_LRCPC)",
-)
+from support import IS_LINUX_ARM, IS_MAC_ARM, IS_MAC_X86
 
 
 class TestCONCURRENT:


### PR DESCRIPTION
Attempt to fix the nightlies. The only remaining ARM vg nightlies fail because of a bug **in** valgrind:

It is deterministic: the same "Unrecognised instruction at 0x35b8702c" on every nightly run. The instruction is 0x38BFC108 = LDAPRB, an ARMv8.3 FEAT_LRCPC load-acquire byte, i.e. an atomic acquire load. The JIT emits it because the arm runner's CPU supports LRCPC, but Ubuntu 24.04's valgrind 3.22.0 can't decode it, so valgrind raises SIGILL and kills pytest mid-suite. Memcheck itself reports 0 errors. The last failure was `test_concurrent.py` addressed in #19  

Bug: https://bugs.kde.org/show_bug.cgi?id=476465
Fix: https://sourceware.org/git/?p=valgrind.git;a=commit;h=41e2f95cf129191555e0048ccbbb392ee0fb155e

But as mentioned that release that has the fix is not published for the ubuntu version in the CI.