### PR TITLE
[cmake] Require only Python Development.Module for the extension build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,13 +16,15 @@ set(CPPINTEROP_GIT_TAG "8d624c621a4b95e36ff73ac708c85a768287478f" CACHE STRING "
 set(CPPINTEROP_SOURCE_DIR "" CACHE PATH
     "Override default CppInterOp built by ExternalProject_Add, with a path to local CppInterOp source")
 
+# The full Development component requires libpython, which manylinux
+# images do not ship and extension modules do not need.
 set(Python_FIND_VIRTUALENV ONLY)
-find_package(Python COMPONENTS Interpreter Development)
+find_package(Python COMPONENTS Interpreter Development.Module)
 if(NOT Python_FOUND)
     set(Python_FIND_VIRTUALENV STANDARD)
-    find_package(Python COMPONENTS Interpreter Development)
+    find_package(Python COMPONENTS Interpreter Development.Module)
 endif()
-if(NOT Python_Development_FOUND)
+if(NOT Python_Development.Module_FOUND)
     message(FATAL_ERROR "Python development headers not found")
 endif()
 


### PR DESCRIPTION
Depend only on a subset of the Python Development component. We only require `Development.Module` when building our `libcppjit` extension, and in fact, manylinux images do not ship `Development.Embed` (`libpython`) so this solves that problem too.