### PR TITLE
[interop] Detect the resource dir of the required system LLVM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,11 +116,13 @@ add_library(cppjit SHARED ${CPYRT_SOURCES} ${INTEROP_SOURCES})
 add_dependencies(cppjit CppInterOp)
 
 # The wrapper anchors these relative spellings at its own load location,
-# falling back to the install prefix (see cppinterop_paths()).
+# falling back to the install prefix (see cppinterop_paths()); the clang
+# major names the versioned compiler probed for the runtime resource dir.
 target_compile_definitions(cppjit PRIVATE
     CPPINTEROP_INSTALL_PREFIX="${CPPINTEROP_INSTALL_PREFIX}"
     CPPINTEROP_LIBRARY="cppjit_backend/lib/libclangCppInterOp${CMAKE_SHARED_LIBRARY_SUFFIX}"
     CPPINTEROP_INCLUDE_DIR="cppjit_backend/include"
+    CPPJIT_CLANG_MAJOR="${LLVM_VERSION_MAJOR}"
 )
 
 target_include_directories(cppjit PRIVATE

--- a/src/interop/interop_wrapper.cxx
+++ b/src/interop/interop_wrapper.cxx
@@ -113,13 +113,22 @@ static interop::TInterp_t acquireOrCreateInterpreter() {
   if (auto existingInterp = Cpp::GetInterpreter())
     return existingInterp;
 
-#if defined(__arm64__) && defined(__APPLE__)
-  // If on apple silicon don't use -march=native
-  return Cpp::CreateInterpreter({"-std=c++17"}, /*GpuArgs=*/{});
-#else
-  return Cpp::CreateInterpreter({"-std=c++17", "-march=native"},
-                                /*GpuArgs=*/{});
+  std::vector<const char*> args = {"-std=c++17"};
+#if !(defined(__arm64__) && defined(__APPLE__))
+  // apple silicon clang rejects -march=native
+  args.push_back("-march=native");
 #endif
+  // Without clang's builtin headers the interpreter fails at its first
+  // #include. CppInterOp probes only bare `clang`; when just
+  // clang-<major> is installed, resolve and pass it explicitly.
+  std::string resourceDir;
+  if (Cpp::DetectResourceDir("clang").empty())
+    resourceDir = Cpp::DetectResourceDir("clang-" CPPJIT_CLANG_MAJOR);
+  if (!resourceDir.empty()) {
+    args.push_back("-resource-dir");
+    args.push_back(resourceDir.c_str());
+  }
+  return Cpp::CreateInterpreter(args, /*GpuArgs=*/{});
 }
 
 static void configureInterpreter(const InterOpPaths& Paths) {


### PR DESCRIPTION
As discussed in the last meeting, this is the first step towards dropping LLVM as a dependency (required for the wheels and binary distributions) and ship the required clang headers. We need to be able to reliably detect the resource dir. Currently `CreateInterpreter` picks up _any_ clang resource dir (naive `clang` probe) that will most likely _not_ be the one that cppjit's `libClangCppInterOp` was built against