### PR TITLE
[build] Move the version provider to tool.dynamic-metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core>=0.10"]
+requires = ["scikit-build-core>=1.0"]
 build-backend = "scikit_build_core.build"
 
 [project]
@@ -24,8 +24,11 @@ maintainers = [
 wheel.install-dir = "."
 wheel.packages = ["python/cppjit", "python/cppjit_backend"]
 cmake.build-type = "Release"
-metadata.version.provider = "scikit_build_core.metadata.regex"
-metadata.version.input = "python/cppjit/_version.py"
+
+[[tool.dynamic-metadata]]
+provider = "scikit_build_core.metadata.regex"
+field = "version"
+input = "python/cppjit/_version.py"
 
 [tool.pytest.ini_options]
 testpaths = ["test"]


### PR DESCRIPTION
Fixes the installation warning:

```
2026-08-20T11:54:26.9411113Z   Preparing metadata (pyproject.toml): started
2026-08-20T11:54:26.9411738Z   Running command Preparing metadata (pyproject.toml)
2026-08-20T11:54:27.2998517Z   WARNING: tool.scikit-build.metadata is deprecated; use the standard top-level [[tool.dynamic-metadata]] instead
2026-08-20T11:54:27.3027613Z   *** scikit-build-core 1.0.3 using CMake 3.31.6 (metadata_wheel)
2026-08-20T11:54:27.3745619Z   Preparing metadata (pyproject.toml): finished with status 'done'
2026-08-20T11:54:27.3766823Z Building wheels for collected packages: cppjit
```