### PR TITLE
[cpyrt] Drop redundant namespace qualification. NFC

### DIFF
--- a/src/cpyrt/API.cxx
+++ b/src/cpyrt/API.cxx
@@ -65,7 +65,7 @@ static bool Initialize() {
   }
 
   if (!gMainDict) {
-    cppjit::cpyrt::PythonGILRAII python_gil_raii;
+    cpyrt::PythonGILRAII python_gil_raii;
     // retrieve the main dictionary
     gMainDict =
         PyModule_GetDict(PyImport_AddModule(const_cast<char*>("__main__")));

--- a/src/cpyrt/API.h
+++ b/src/cpyrt/API.h
@@ -131,8 +131,7 @@ public:
 
 // create a converter based on its full type name and dimensions
 CPYRT_EXTERN Converter* CreateConverter(const std::string& name, cdims_t = 0);
-CPYRT_EXTERN Converter* CreateConverter(cppjit::interop::TCppType_t type,
-                                        cdims_t = 0);
+CPYRT_EXTERN Converter* CreateConverter(interop::TCppType_t type, cdims_t = 0);
 
 // delete a previously created converter
 CPYRT_EXTERN void DestroyConverter(Converter* p);
@@ -155,8 +154,8 @@ public:
   virtual ~Executor();
 
   // callback when executing a function from Python
-  virtual PyObject* Execute(cppjit::interop::TCppMethod_t,
-                            cppjit::interop::TCppObject_t, CallContext*) = 0;
+  virtual PyObject* Execute(interop::TCppMethod_t, interop::TCppObject_t,
+                            CallContext*) = 0;
 
   // if an executor has state, it will be unique per function, shared otherwise
   virtual bool HasState() { return false; }
@@ -164,8 +163,7 @@ public:
 
 // create an executor based on its full type name
 CPYRT_EXTERN Executor* CreateExecutor(const std::string& name, cdims_t = 0);
-CPYRT_EXTERN Executor* CreateExecutor(cppjit::interop::TCppType_t type,
-                                      cdims_t = 0);
+CPYRT_EXTERN Executor* CreateExecutor(interop::TCppType_t type, cdims_t = 0);
 
 // delete a previously created executor
 CPYRT_EXTERN void DestroyConverter(Converter* p);
@@ -182,8 +180,8 @@ CPYRT_EXTERN bool RegisterExecutorAlias(const std::string& name,
 CPYRT_EXTERN bool UnregisterExecutor(const std::string& name);
 
 // helper for calling into C++ from a custom executor
-CPYRT_EXTERN void* CallVoidP(cppjit::interop::TCppMethod_t,
-                             cppjit::interop::TCppObject_t, CallContext*);
+CPYRT_EXTERN void* CallVoidP(interop::TCppMethod_t, interop::TCppObject_t,
+                             CallContext*);
 
 //- C++ access to cppjit objects ---------------------------------------------
 
@@ -200,9 +198,9 @@ CPYRT_EXTERN void* Instance_AsVoidPtr(PyObject* pyobject);
 CPYRT_EXTERN PyObject* Instance_FromVoidPtr(void* addr,
                                             const std::string& classname,
                                             bool python_owns = false);
-CPYRT_EXTERN PyObject*
-Instance_FromVoidPtr(void* addr, cppjit::interop::TCppScope_t klass_scope,
-                     bool python_owns = false);
+CPYRT_EXTERN PyObject* Instance_FromVoidPtr(void* addr,
+                                            interop::TCppScope_t klass_scope,
+                                            bool python_owns = false);
 // type verifiers for C++ Scope
 CPYRT_EXTERN bool Scope_Check(PyObject* pyobject);
 CPYRT_EXTERN bool Scope_CheckExact(PyObject* pyobject);

--- a/src/cpyrt/CPPConstructor.h
+++ b/src/cpyrt/CPPConstructor.h
@@ -12,9 +12,9 @@ public:
 
 public:
   PyObject* GetDocString() override;
-  PyObject* Reflex(cppjit::interop::Reflex::RequestId_t,
-                   cppjit::interop::Reflex::FormatId_t =
-                       cppjit::interop::Reflex::OPTIMAL) override;
+  PyObject*
+      Reflex(interop::Reflex::RequestId_t,
+             interop::Reflex::FormatId_t = interop::Reflex::OPTIMAL) override;
 
   PyCallable* Clone() override { return new CPPConstructor(*this); }
   PyObject* Call(CPPInstance*& self, cpyrt_PyArgs_t args, size_t nargsf,
@@ -27,8 +27,7 @@ protected:
 // specialization for multiple inheritance disambiguation
 class CPPMultiConstructor : public CPPConstructor {
 public:
-  CPPMultiConstructor(cppjit::interop::TCppScope_t scope,
-                      cppjit::interop::TCppMethod_t method);
+  CPPMultiConstructor(interop::TCppScope_t scope, interop::TCppMethod_t method);
   CPPMultiConstructor(const CPPMultiConstructor&);
   CPPMultiConstructor& operator=(const CPPMultiConstructor&);
 

--- a/src/cpyrt/CPPDataMember.h
+++ b/src/cpyrt/CPPDataMember.h
@@ -13,10 +13,8 @@ class CPPInstance;
 
 class CPPDataMember {
 public:
-  void Set(cppjit::interop::TCppScope_t scope,
-           cppjit::interop::TCppScope_t var);
-  void Set(cppjit::interop::TCppScope_t scope, const std::string& name,
-           void* address);
+  void Set(interop::TCppScope_t scope, interop::TCppScope_t var);
+  void Set(interop::TCppScope_t scope, const std::string& name, void* address);
 
   std::string GetName();
   void* GetAddress(CPPInstance* pyobj /* owner */);
@@ -25,8 +23,8 @@ public: // public, as the python C-API works with C structs
   PyObject_HEAD intptr_t fOffset;
   long fFlags;
   Converter* fConverter;
-  cppjit::interop::TCppScope_t fScope;
-  cppjit::interop::TCppScope_t fEnclosingScope;
+  interop::TCppScope_t fScope;
+  interop::TCppScope_t fEnclosingScope;
   PyObject* fDescription;
   PyObject* fDoc;
 
@@ -50,8 +48,8 @@ template <typename T> inline bool CPPDataMember_CheckExact(T* object) {
 }
 
 //- creation -----------------------------------------------------------------
-inline CPPDataMember* CPPDataMember_New(cppjit::interop::TCppScope_t scope,
-                                        cppjit::interop::TCppScope_t var) {
+inline CPPDataMember* CPPDataMember_New(interop::TCppScope_t scope,
+                                        interop::TCppScope_t var) {
   // Create an initialize a new property descriptor, given the C++ datum.
   CPPDataMember* pyprop = (CPPDataMember*)CPPDataMember_Type.tp_new(
       &CPPDataMember_Type, nullptr, nullptr);
@@ -59,9 +57,9 @@ inline CPPDataMember* CPPDataMember_New(cppjit::interop::TCppScope_t scope,
   return pyprop;
 }
 
-inline CPPDataMember*
-CPPDataMember_NewConstant(cppjit::interop::TCppScope_t scope,
-                          const std::string& name, void* address) {
+inline CPPDataMember* CPPDataMember_NewConstant(interop::TCppScope_t scope,
+                                                const std::string& name,
+                                                void* address) {
   // Create an initialize a new property descriptor, given the C++ datum.
   CPPDataMember* pyprop = (CPPDataMember*)CPPDataMember_Type.tp_new(
       &CPPDataMember_Type, nullptr, nullptr);

--- a/src/cpyrt/CPPEnum.h
+++ b/src/cpyrt/CPPEnum.h
@@ -8,12 +8,10 @@ namespace cppjit::cpyrt {
 typedef PyObject CPPEnum;
 
 //- creation -----------------------------------------------------------------
-CPPEnum* CPPEnum_New(const std::string& name,
-                     cppjit::interop::TCppScope_t scope);
+CPPEnum* CPPEnum_New(const std::string& name, interop::TCppScope_t scope);
 
 PyObject* pyval_from_enum(const std::string& enum_type, PyObject* pytype,
-                          PyObject* btype,
-                          cppjit::interop::TCppScope_t enum_constant);
+                          PyObject* btype, interop::TCppScope_t enum_constant);
 } // namespace cppjit::cpyrt
 
 #endif // !CPYRT_CPPENUM_H

--- a/src/cpyrt/CPPExcInstance.h
+++ b/src/cpyrt/CPPExcInstance.h
@@ -3,7 +3,7 @@
 
 //////////////////////////////////////////////////////////////////////////////
 //                                                                          //
-// Cpycppjit::interop::CPPExceptionInstance //
+// cppjit::cpyrt::CPPExceptionInstance                                      //
 //                                                                          //
 // Python-side proxy, encapsulaties a C++ exception object.                 //
 //                                                                          //

--- a/src/cpyrt/CPPInstance.cxx
+++ b/src/cpyrt/CPPInstance.cxx
@@ -71,7 +71,7 @@ struct ExtendedData {
   cpyrt::CPPSmartClass* fSmartClass;
 
   // for back-referencing from Python-derived instances
-  cppjit::cpyrt::DispatchPtr* fDispatchPtr;
+  cpyrt::DispatchPtr* fDispatchPtr;
 
   // for representing T* as a low-level array
   Py_ssize_t fArraySize;

--- a/src/cpyrt/CPPInstance.h
+++ b/src/cpyrt/CPPInstance.h
@@ -3,7 +3,7 @@
 
 //////////////////////////////////////////////////////////////////////////////
 //                                                                          //
-// Cpycppjit::interop::CPPInstance //
+// cppjit::cpyrt::CPPInstance                                               //
 //                                                                          //
 // Python-side proxy, encapsulaties a C++ object.                           //
 //                                                                          //
@@ -62,7 +62,7 @@ public:
   // access to C++ pointer and type
   void* GetObject();
   void*& GetObjectRaw() { return IsExtended() ? *(void**)fObject : fObject; }
-  cppjit::interop::TCppScope_t ObjectIsA(bool check_smart = true) const;
+  interop::TCppScope_t ObjectIsA(bool check_smart = true) const;
 
   // memory management: ownership of the underlying C++ object
   void PythonOwns();
@@ -74,8 +74,8 @@ public:
   // smart pointer management
   void SetSmart(PyObject* smart_type);
   void* GetSmartObject() { return GetObjectRaw(); }
-  cppjit::interop::TCppScope_t GetSmartIsA() const;
-  cppjit::interop::TCppScope_t GetSmartUnderlyingType() const;
+  interop::TCppScope_t GetSmartIsA() const;
+  interop::TCppScope_t GetSmartUnderlyingType() const;
 
   // cross-inheritance dispatch
   void SetDispatchPtr(void*);
@@ -116,8 +116,7 @@ inline void* CPPInstance::GetObject() {
 
 #ifndef Py_LIMITED_API
 //----------------------------------------------------------------------------
-inline cppjit::interop::TCppScope_t
-CPPInstance::ObjectIsA(bool check_smart) const {
+inline interop::TCppScope_t CPPInstance::ObjectIsA(bool check_smart) const {
   // Retrieve the C++ type identifier (or raw type if smart).
   if (check_smart || !IsSmart())
     return ((CPPClass*)Py_TYPE(this))->fCppType;

--- a/src/cpyrt/CPPMethod.h
+++ b/src/cpyrt/CPPMethod.h
@@ -40,8 +40,7 @@ public:
 
 class CPPMethod : public PyCallable {
 public:
-  CPPMethod(cppjit::interop::TCppScope_t scope,
-            cppjit::interop::TCppMethod_t method);
+  CPPMethod(interop::TCppScope_t scope, interop::TCppMethod_t method);
   CPPMethod(const CPPMethod&);
   CPPMethod& operator=(const CPPMethod&);
   virtual ~CPPMethod();
@@ -52,9 +51,9 @@ public:
   PyObject* GetSignatureTypes() override;
   PyObject* GetPrototype(bool show_formalargs = true) override;
   PyObject* GetTypeName() override;
-  PyObject* Reflex(cppjit::interop::Reflex::RequestId_t request,
-                   cppjit::interop::Reflex::FormatId_t =
-                       cppjit::interop::Reflex::OPTIMAL) override;
+  PyObject*
+  Reflex(interop::Reflex::RequestId_t request,
+         interop::Reflex::FormatId_t = interop::Reflex::OPTIMAL) override;
 
   int GetPriority() override;
   bool IsGreedy() override;
@@ -65,7 +64,7 @@ public:
   bool IsConst() override;
 
   PyObject* GetScopeProxy() override;
-  cppjit::interop::TCppFuncAddr_t GetFunctionAddress() override;
+  interop::TCppFuncAddr_t GetFunctionAddress() override;
 
   PyCallable* Clone() override { return new CPPMethod(*this); }
 
@@ -84,8 +83,8 @@ protected:
                          CallContext* ctxt = nullptr);
   PyObject* Execute(void* self, ptrdiff_t offset, CallContext* ctxt = nullptr);
 
-  cppjit::interop::TCppMethod_t GetMethod() { return fMethod; }
-  cppjit::interop::TCppScope_t GetScope() { return fScope; }
+  interop::TCppMethod_t GetMethod() { return fMethod; }
+  interop::TCppScope_t GetScope() { return fScope; }
   Executor* GetExecutor() { return fExecutor; }
   std::string GetSignatureString(bool show_formalargs = true);
   std::string GetReturnTypeName();
@@ -106,8 +105,8 @@ private:
 
 private:
   // representation
-  cppjit::interop::TCppMethod_t fMethod;
-  cppjit::interop::TCppScope_t fScope;
+  interop::TCppMethod_t fMethod;
+  interop::TCppScope_t fScope;
   Executor* fExecutor;
 
   // call dispatch buffers

--- a/src/cpyrt/CPPOperator.h
+++ b/src/cpyrt/CPPOperator.h
@@ -11,8 +11,8 @@ namespace cppjit::cpyrt {
 
 class CPPOperator : public CPPMethod {
 public:
-  CPPOperator(cppjit::interop::TCppScope_t scope,
-              cppjit::interop::TCppMethod_t method, const std::string& name);
+  CPPOperator(interop::TCppScope_t scope, interop::TCppMethod_t method,
+              const std::string& name);
 
 public:
   PyCallable* Clone() override { return new CPPOperator(*this); }

--- a/src/cpyrt/CPPScope.h
+++ b/src/cpyrt/CPPScope.h
@@ -35,8 +35,7 @@ namespace cppjit::cpyrt {
       @version 2.0
  */
 
-typedef std::unordered_map<cppjit::interop::TCppObject_t, PyObject*>
-    CppToPyMap_t;
+typedef std::unordered_map<interop::TCppObject_t, PyObject*> CppToPyMap_t;
 namespace Utility {
 struct PyOperators;
 }
@@ -60,7 +59,7 @@ public:
 
 public:
   PyHeapTypeObject fType;
-  cppjit::interop::TCppScope_t fCppType;
+  interop::TCppScope_t fCppType;
   uint32_t fFlags;
   union {
     CppToPyMap_t* fCppObjects;      // classes only
@@ -77,8 +76,8 @@ typedef CPPScope CPPClass;
 
 class CPPSmartClass : public CPPClass {
 public:
-  cppjit::interop::TCppScope_t fUnderlyingType;
-  cppjit::interop::TCppMethod_t fDereferencer;
+  interop::TCppScope_t fUnderlyingType;
+  interop::TCppMethod_t fDereferencer;
 };
 
 //- metatype type and type verification --------------------------------------
@@ -96,8 +95,7 @@ template <typename T> inline bool CPPScope_CheckExact(T* object) {
 }
 
 //- creation -----------------------------------------------------------------
-inline CPPScope* CPPScopeMeta_New(cppjit::interop::TCppScope_t klass,
-                                  PyObject* args) {
+inline CPPScope* CPPScopeMeta_New(interop::TCppScope_t klass, PyObject* args) {
   // Create and initialize a new scope meta class
   CPPScope* pymeta =
       (CPPScope*)PyType_Type.tp_new(&CPPScope_Type, args, nullptr);

--- a/src/cpyrt/CallContext.h
+++ b/src/cpyrt/CallContext.h
@@ -119,7 +119,7 @@ struct CallContext {
 
 public:
   // info/status
-  cppjit::interop::TCppScope_t fCurScope;
+  interop::TCppScope_t fCurScope;
   PyObject* fPyContext;
   uint32_t fFlags;
 

--- a/src/cpyrt/Converters.h
+++ b/src/cpyrt/Converters.h
@@ -35,7 +35,7 @@ public:
 // create/destroy converter from fully qualified type (public API)
 CPYRT_EXPORT Converter* CreateConverter(const std::string& fullType,
                                         cdims_t dims = 0);
-CPYRT_EXPORT Converter* CreateConverter(cppjit::interop::TCppType_t type,
+CPYRT_EXPORT Converter* CreateConverter(interop::TCppType_t type,
                                         cdims_t dims = 0);
 CPYRT_EXPORT void DestroyConverter(Converter* p);
 typedef Converter* (*cf_t)(cdims_t d);
@@ -75,11 +75,10 @@ private:
 
 template <bool ISCONST> class InstancePtrConverter : public VoidArrayConverter {
 public:
-  InstancePtrConverter(cppjit::interop::TCppScope_t klass,
-                       bool keepControl = false,
+  InstancePtrConverter(interop::TCppScope_t klass, bool keepControl = false,
                        const std::string& failureMsg = std::string())
       : VoidArrayConverter(keepControl, failureMsg),
-        fClass(cppjit::interop::GetUnderlyingScope(klass)) {}
+        fClass(interop::GetUnderlyingScope(klass)) {}
 
 public:
   bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
@@ -88,7 +87,7 @@ public:
                 PyObject* ctxt = nullptr) override;
 
 protected:
-  cppjit::interop::TCppScope_t fClass;
+  interop::TCppScope_t fClass;
 };
 
 class StrictInstancePtrConverter : public InstancePtrConverter<false> {

--- a/src/cpyrt/CustomPyTypes.h
+++ b/src/cpyrt/CustomPyTypes.h
@@ -12,7 +12,7 @@ namespace cppjit::cpyrt {
 
 //- custom type representing typedef to pointer of class ---------------------
 struct typedefpointertoclassobject {
-  PyObject_HEAD cppjit::interop::TCppScope_t fCppType;
+  PyObject_HEAD interop::TCppScope_t fCppType;
 };
 
 extern PyTypeObject TypedefPointerToClass_Type;
@@ -52,8 +52,8 @@ class Converter;
 struct vectoriterobject : public indexiterobject {
   void* vi_data;
   Py_ssize_t vi_stride;
-  cppjit::cpyrt::Converter* vi_converter;
-  cppjit::interop::TCppScope_t vi_klass;
+  Converter* vi_converter;
+  interop::TCppScope_t vi_klass;
   int vi_flags;
 
   enum EFlags {

--- a/src/cpyrt/DeclareConverters.h
+++ b/src/cpyrt/DeclareConverters.h
@@ -281,7 +281,7 @@ public:
 
 class InstanceRefConverter : public Converter {
 public:
-  InstanceRefConverter(cppjit::interop::TCppScope_t klass, bool isConst)
+  InstanceRefConverter(interop::TCppScope_t klass, bool isConst)
       : fClass(klass), fIsConst(isConst) {}
 
 public:
@@ -291,13 +291,13 @@ public:
   std::string GetFailureMsg() override { return "[InstanceRefConverter]"; };
 
 protected:
-  cppjit::interop::TCppScope_t fClass;
+  interop::TCppScope_t fClass;
   bool fIsConst;
 };
 
 class InstanceMoveConverter : public InstanceRefConverter {
 public:
-  InstanceMoveConverter(cppjit::interop::TCppScope_t klass)
+  InstanceMoveConverter(interop::TCppScope_t klass)
       : InstanceRefConverter(klass, true) {}
   bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
   std::string GetFailureMsg() override { return "[InstanceMoveConverter]"; };
@@ -317,7 +317,7 @@ public:
 
 class InstanceArrayConverter : public InstancePtrConverter<false> {
 public:
-  InstanceArrayConverter(cppjit::interop::TCppScope_t klass, cdims_t dims,
+  InstanceArrayConverter(interop::TCppScope_t klass, cdims_t dims,
                          bool keepControl = false)
       : InstancePtrConverter<false>(klass, keepControl), fShape(dims) {}
   InstanceArrayConverter(const InstanceArrayConverter&) = delete;
@@ -455,8 +455,7 @@ protected:
 // smart pointer converter
 class SmartPtrConverter : public Converter {
 public:
-  SmartPtrConverter(cppjit::interop::TCppScope_t smart,
-                    cppjit::interop::TCppScope_t underlying,
+  SmartPtrConverter(interop::TCppScope_t smart, interop::TCppScope_t underlying,
                     bool keepControl = false, bool isRef = false)
       : fSmartPtrType(smart), fUnderlyingType(underlying),
         fKeepControl(keepControl), fIsRef(isRef) {}
@@ -471,8 +470,8 @@ public:
 protected:
   virtual bool GetAddressSpecialCase(PyObject*, void*&) { return false; }
 
-  cppjit::interop::TCppScope_t fSmartPtrType;
-  cppjit::interop::TCppScope_t fUnderlyingType;
+  interop::TCppScope_t fSmartPtrType;
+  interop::TCppScope_t fUnderlyingType;
   bool fKeepControl;
   bool fIsRef;
 };
@@ -480,7 +479,7 @@ protected:
 // initializer lists
 class InitializerListConverter : public InstanceConverter {
 public:
-  InitializerListConverter(cppjit::interop::TCppScope_t klass,
+  InitializerListConverter(interop::TCppScope_t klass,
                            std::string const& value_type);
   InitializerListConverter(const InitializerListConverter&) = delete;
   InitializerListConverter& operator=(const InitializerListConverter&) = delete;
@@ -498,7 +497,7 @@ protected:
   void* fBuffer = nullptr;
   std::vector<Converter*> fConverters;
   std::string fValueTypeName;
-  cppjit::interop::TCppScope_t fValueType;
+  interop::TCppScope_t fValueType;
   size_t fValueSize;
 };
 

--- a/src/cpyrt/DeclareExecutors.h
+++ b/src/cpyrt/DeclareExecutors.h
@@ -19,8 +19,8 @@ namespace {
 #define CPPJIT_DECL_EXEC(name)                                                 \
   class name##Executor : public Executor {                                     \
   public:                                                                      \
-    PyObject* Execute(cppjit::interop::TCppMethod_t,                           \
-                      cppjit::interop::TCppObject_t, CallContext*) override;   \
+    PyObject* Execute(interop::TCppMethod_t, interop::TCppObject_t,            \
+                      CallContext*) override;                                  \
   }
 
 // executors for built-ins
@@ -60,8 +60,8 @@ CPPJIT_DECL_EXEC(CString32);
                                                                                \
   public:                                                                      \
     name##ArrayExecutor(dims_t dims) : fShape(dims) {}                         \
-    PyObject* Execute(cppjit::interop::TCppMethod_t,                           \
-                      cppjit::interop::TCppObject_t, CallContext*) override;   \
+    PyObject* Execute(interop::TCppMethod_t, interop::TCppObject_t,            \
+                      CallContext*) override;                                  \
     bool HasState() override { return true; }                                  \
   }
 CPPJIT_ARRAY_DECL_EXEC(Void);
@@ -94,30 +94,30 @@ CPPJIT_DECL_EXEC(STLWString);
 
 class InstancePtrExecutor : public Executor {
 public:
-  InstancePtrExecutor(cppjit::interop::TCppScope_t klass) : fClass(klass) {}
-  PyObject* Execute(cppjit::interop::TCppMethod_t,
-                    cppjit::interop::TCppObject_t, CallContext*) override;
+  InstancePtrExecutor(interop::TCppScope_t klass) : fClass(klass) {}
+  PyObject* Execute(interop::TCppMethod_t, interop::TCppObject_t,
+                    CallContext*) override;
   bool HasState() override { return true; }
 
 protected:
-  cppjit::interop::TCppScope_t fClass;
+  interop::TCppScope_t fClass;
 };
 
 class InstanceExecutor : public Executor {
 public:
-  InstanceExecutor(cppjit::interop::TCppScope_t klass);
-  PyObject* Execute(cppjit::interop::TCppMethod_t,
-                    cppjit::interop::TCppObject_t, CallContext*) override;
+  InstanceExecutor(interop::TCppScope_t klass);
+  PyObject* Execute(interop::TCppMethod_t, interop::TCppObject_t,
+                    CallContext*) override;
   bool HasState() override { return true; }
 
 protected:
-  cppjit::interop::TCppScope_t fClass;
+  interop::TCppScope_t fClass;
   uint32_t fFlags;
 };
 
 class IteratorExecutor : public InstanceExecutor {
 public:
-  IteratorExecutor(cppjit::interop::TCppScope_t klass);
+  IteratorExecutor(interop::TCppScope_t klass);
 };
 
 CPPJIT_DECL_EXEC(Constructor);
@@ -126,8 +126,8 @@ CPPJIT_DECL_EXEC(PyObject);
 #define CPPJIT_DECL_REFEXEC(name)                                              \
   class name##RefExecutor : public RefExecutor {                               \
   public:                                                                      \
-    PyObject* Execute(cppjit::interop::TCppMethod_t,                           \
-                      cppjit::interop::TCppObject_t, CallContext*) override;   \
+    PyObject* Execute(interop::TCppMethod_t, interop::TCppObject_t,            \
+                      CallContext*) override;                                  \
   }
 
 CPPJIT_DECL_REFEXEC(Bool);
@@ -152,34 +152,34 @@ CPPJIT_DECL_REFEXEC(STLString);
 // special cases
 class InstanceRefExecutor : public RefExecutor {
 public:
-  InstanceRefExecutor(cppjit::interop::TCppScope_t klass) : fClass(klass) {}
-  PyObject* Execute(cppjit::interop::TCppMethod_t,
-                    cppjit::interop::TCppObject_t, CallContext*) override;
+  InstanceRefExecutor(interop::TCppScope_t klass) : fClass(klass) {}
+  PyObject* Execute(interop::TCppMethod_t, interop::TCppObject_t,
+                    CallContext*) override;
 
 protected:
-  cppjit::interop::TCppScope_t fClass;
+  interop::TCppScope_t fClass;
 };
 
 class InstancePtrPtrExecutor : public InstanceRefExecutor {
 public:
   using InstanceRefExecutor::InstanceRefExecutor;
-  PyObject* Execute(cppjit::interop::TCppMethod_t,
-                    cppjit::interop::TCppObject_t, CallContext*) override;
+  PyObject* Execute(interop::TCppMethod_t, interop::TCppObject_t,
+                    CallContext*) override;
 };
 
 class InstancePtrRefExecutor : public InstanceRefExecutor {
 public:
   using InstanceRefExecutor::InstanceRefExecutor;
-  PyObject* Execute(cppjit::interop::TCppMethod_t,
-                    cppjit::interop::TCppObject_t, CallContext*) override;
+  PyObject* Execute(interop::TCppMethod_t, interop::TCppObject_t,
+                    CallContext*) override;
 };
 
 class InstanceArrayExecutor : public InstancePtrExecutor {
 public:
-  InstanceArrayExecutor(cppjit::interop::TCppScope_t klass, dim_t array_size)
+  InstanceArrayExecutor(interop::TCppScope_t klass, dim_t array_size)
       : InstancePtrExecutor(klass), fSize(array_size) {}
-  PyObject* Execute(cppjit::interop::TCppMethod_t,
-                    cppjit::interop::TCppObject_t, CallContext*) override;
+  PyObject* Execute(interop::TCppMethod_t, interop::TCppObject_t,
+                    CallContext*) override;
 
 protected:
   dim_t fSize;
@@ -189,8 +189,8 @@ class FunctionPointerExecutor : public Executor {
 public:
   FunctionPointerExecutor(const std::string& ret, const std::string& sig)
       : fRetType(ret), fSignature(sig) {}
-  PyObject* Execute(cppjit::interop::TCppMethod_t,
-                    cppjit::interop::TCppObject_t, CallContext*) override;
+  PyObject* Execute(interop::TCppMethod_t, interop::TCppObject_t,
+                    CallContext*) override;
 
 protected:
   std::string fRetType;

--- a/src/cpyrt/Executors.h
+++ b/src/cpyrt/Executors.h
@@ -17,8 +17,8 @@ struct CallContext;
 class CPYRT_CLASS_EXPORT Executor {
 public:
   virtual ~Executor();
-  virtual PyObject* Execute(cppjit::interop::TCppMethod_t,
-                            cppjit::interop::TCppObject_t, CallContext*) = 0;
+  virtual PyObject* Execute(interop::TCppMethod_t, interop::TCppObject_t,
+                            CallContext*) = 0;
   virtual bool HasState() { return false; }
 };
 
@@ -35,8 +35,7 @@ protected:
 
 // create/destroy executor from fully qualified type (public API)
 CPYRT_EXPORT Executor* CreateExecutor(const std::string& fullType, cdims_t = 0);
-CPYRT_EXPORT Executor* CreateExecutor(cppjit::interop::TCppType_t type,
-                                      cdims_t = 0);
+CPYRT_EXPORT Executor* CreateExecutor(interop::TCppType_t type, cdims_t = 0);
 CPYRT_EXPORT void DestroyExecutor(Executor* p);
 typedef Executor* (*ef_t)(cdims_t);
 CPYRT_EXPORT bool RegisterExecutor(const std::string& name, ef_t fac);
@@ -45,8 +44,8 @@ CPYRT_EXPORT bool RegisterExecutorAlias(const std::string& name,
 CPYRT_EXPORT bool UnregisterExecutor(const std::string& name);
 
 // helper for the actual call
-CPYRT_EXPORT void* CallVoidP(cppjit::interop::TCppMethod_t,
-                             cppjit::interop::TCppObject_t, CallContext*);
+CPYRT_EXPORT void* CallVoidP(interop::TCppMethod_t, interop::TCppObject_t,
+                             CallContext*);
 
 } // namespace cppjit::cpyrt
 

--- a/src/cpyrt/MemoryRegulator.h
+++ b/src/cpyrt/MemoryRegulator.h
@@ -11,8 +11,8 @@ namespace cppjit::cpyrt {
 
 class CPPInstance;
 
-typedef std::function<std::pair<bool, bool>(cppjit::interop::TCppObject_t,
-                                            cppjit::interop::TCppScope_t)>
+typedef std::function<std::pair<bool, bool>(interop::TCppObject_t,
+                                            interop::TCppScope_t)>
     MemHook_t;
 
 class MemoryRegulator {
@@ -23,19 +23,19 @@ public:
   MemoryRegulator();
 
   // callback from C++-side frameworks
-  static bool RecursiveRemove(cppjit::interop::TCppObject_t cppobj,
-                              cppjit::interop::TCppScope_t klass);
+  static bool RecursiveRemove(interop::TCppObject_t cppobj,
+                              interop::TCppScope_t klass);
 
   // called when a new python proxy object is created
   static bool RegisterPyObject(CPPInstance* pyobj,
-                               cppjit::interop::TCppObject_t cppobj);
+                               interop::TCppObject_t cppobj);
 
   // called when a the python proxy object is about to be garbage collected or
   // when it is about to delete the proxied C++ object, if owned
   static bool UnregisterPyObject(CPPInstance* pyobj, PyObject* pyclass);
 
   // new reference to python object matching cppobj, or 0 on failure
-  static PyObject* RetrievePyObject(cppjit::interop::TCppObject_t cppobj,
+  static PyObject* RetrievePyObject(interop::TCppObject_t cppobj,
                                     PyObject* pyclass);
 
   // set hooks for custom memory regulation

--- a/src/cpyrt/ProxyWrappers.h
+++ b/src/cpyrt/ProxyWrappers.h
@@ -10,13 +10,13 @@
 namespace cppjit::cpyrt {
 
 // construct a Python shadow class for the named C++ class
-PyObject* GetScopeProxy(cppjit::interop::TCppScope_t);
+PyObject* GetScopeProxy(interop::TCppScope_t);
 PyObject* CreateScopeProxy(PyObject*, PyObject* args);
 PyObject* CreateScopeProxy(const std::string& scope_name,
                            PyObject* parent = nullptr,
                            const unsigned flags = 0);
 
-PyObject* CreateScopeProxy(cppjit::interop::TCppScope_t scope,
+PyObject* CreateScopeProxy(interop::TCppScope_t scope,
                            PyObject* parent = nullptr,
                            const unsigned flags = 0);
 // C++ exceptions form a special case b/c they have to derive from BaseException
@@ -24,14 +24,13 @@ PyObject* CreateExcScopeProxy(PyObject* pyscope, PyObject* pyname,
                               PyObject* parent);
 
 // bind a C++ object into a Python proxy object (flags are CPPInstance::Default)
-PyObject* BindCppObjectNoCast(cppjit::interop::TCppObject_t object,
-                              cppjit::interop::TCppScope_t klass,
+PyObject* BindCppObjectNoCast(interop::TCppObject_t object,
+                              interop::TCppScope_t klass,
                               const unsigned flags = 0);
-PyObject* BindCppObject(cppjit::interop::TCppObject_t object,
-                        cppjit::interop::TCppScope_t klass,
-                        const unsigned flags = 0);
-PyObject* BindCppObjectArray(cppjit::interop::TCppObject_t address,
-                             cppjit::interop::TCppScope_t klass, cdims_t dims);
+PyObject* BindCppObject(interop::TCppObject_t object,
+                        interop::TCppScope_t klass, const unsigned flags = 0);
+PyObject* BindCppObjectArray(interop::TCppObject_t address,
+                             interop::TCppScope_t klass, cdims_t dims);
 
 } // namespace cppjit::cpyrt
 

--- a/src/cpyrt/PyCallable.h
+++ b/src/cpyrt/PyCallable.h
@@ -22,9 +22,9 @@ public:
   virtual PyObject* GetPrototype(bool show_formalargs = true) = 0;
   virtual PyObject* GetTypeName() { return GetPrototype(false); }
   virtual PyObject* GetDocString() { return GetPrototype(); }
-  virtual PyObject* Reflex(cppjit::interop::Reflex::RequestId_t request,
-                           cppjit::interop::Reflex::FormatId_t format =
-                               cppjit::interop::Reflex::OPTIMAL) {
+  virtual PyObject*
+  Reflex(interop::Reflex::RequestId_t request,
+         interop::Reflex::FormatId_t format = interop::Reflex::OPTIMAL) {
     PyErr_Format(PyExc_ValueError, "unsupported reflex request %d or format %d",
                  request, format);
     return nullptr;
@@ -39,7 +39,7 @@ public:
   virtual bool IsConst() { return false; }
 
   virtual PyObject* GetScopeProxy() = 0;
-  virtual cppjit::interop::TCppFuncAddr_t GetFunctionAddress() = 0;
+  virtual interop::TCppFuncAddr_t GetFunctionAddress() = 0;
 
   virtual PyCallable* Clone() = 0;
 

--- a/src/cpyrt/Pythonize.cxx
+++ b/src/cpyrt/Pythonize.cxx
@@ -609,7 +609,7 @@ static PyObject* vector_iter(PyObject* v) {
             vi->vi_flags = vectoriterobject::kNeedLifeLine;
         }
       } else
-        vi->vi_converter = cppjit::cpyrt::CreateConverter(value_type);
+        vi->vi_converter = CreateConverter(value_type);
       if (!vi->vi_stride)
         vi->vi_stride = interop::SizeOfType(value_type);
 

--- a/src/cpyrt/Pythonize.h
+++ b/src/cpyrt/Pythonize.h
@@ -7,7 +7,7 @@
 namespace cppjit::cpyrt {
 
 // make the named C++ class more python-like
-bool Pythonize(PyObject* pyclass, cppjit::interop::TCppScope_t scope);
+bool Pythonize(PyObject* pyclass, interop::TCppScope_t scope);
 
 } // namespace cppjit::cpyrt
 

--- a/src/cpyrt/TupleOfInstances.h
+++ b/src/cpyrt/TupleOfInstances.h
@@ -24,9 +24,8 @@ template <typename T> inline bool TupleOfInstances_CheckExact(T* object) {
   return object && Py_TYPE(object) == &TupleOfInstances_Type;
 }
 
-PyObject* TupleOfInstances_New(cppjit::interop::TCppObject_t address,
-                               cppjit::interop::TCppScope_t klass,
-                               cdims_t dims);
+PyObject* TupleOfInstances_New(interop::TCppObject_t address,
+                               interop::TCppScope_t klass, cdims_t dims);
 
 } // namespace cppjit::cpyrt
 

--- a/src/cpyrt/Utility.h
+++ b/src/cpyrt/Utility.h
@@ -32,13 +32,12 @@ bool AddToClass(PyObject* pyclass, const char* label, PyCallable* pyfunc);
 
 // helpers for dynamically constructing operators
 PyCallable* FindUnaryOperator(PyObject* pyclass, const char* op);
-PyCallable* FindBinaryOperator(
-    PyObject* left, PyObject* right, const char* op,
-    cppjit::interop::TCppScope_t scope = cppjit::interop::TCppScope_t{});
+PyCallable*
+FindBinaryOperator(PyObject* left, PyObject* right, const char* op,
+                   interop::TCppScope_t scope = interop::TCppScope_t{});
 PyCallable* FindBinaryOperator(
     const std::string& lcname, const std::string& rcname, const char* op,
-    cppjit::interop::TCppScope_t scope = cppjit::interop::TCppScope_t{},
-    bool reverse = false);
+    interop::TCppScope_t scope = interop::TCppScope_t{}, bool reverse = false);
 
 // helper for template classes and methods
 enum ArgPreference { kNone, kPointer, kReference, kValue };

--- a/src/cpyrt/cppjit_interop.h
+++ b/src/cpyrt/cppjit_interop.h
@@ -163,7 +163,7 @@ TCppType_t GetType(const std::string& name, bool enable_slow_lookup = false);
 CPPJIT_IMPORT
 bool AppendTypesSlow(const std::string& name,
                      std::vector<Cpp::TemplateArgInfo>& types,
-                     cppjit::interop::TCppScope_t parent = nullptr);
+                     interop::TCppScope_t parent = nullptr);
 CPPJIT_IMPORT
 TCppType_t GetComplexType(const std::string& element_type);
 CPPJIT_IMPORT
@@ -296,7 +296,7 @@ void GetAllCppNames(TCppScope_t scope, std::set<std::string>& cppnames);
 
 // namespace reflection information ------------------------------------------
 CPPJIT_IMPORT
-std::vector<cppjit::interop::TCppScope_t> GetUsingNamespaces(TCppScope_t);
+std::vector<interop::TCppScope_t> GetUsingNamespaces(TCppScope_t);
 
 // class reflection information ----------------------------------------------
 CPPJIT_IMPORT
@@ -387,8 +387,7 @@ CPPJIT_IMPORT
 TCppMethod_t GetMethodTemplate(TCppScope_t scope, const std::string& name,
                                const std::string& proto);
 CPPJIT_IMPORT
-void GetClassOperators(cppjit::interop::TCppScope_t klass,
-                       const std::string& opname,
+void GetClassOperators(interop::TCppScope_t klass, const std::string& opname,
                        std::vector<TCppMethod_t>& operators);
 CPPJIT_IMPORT
 TCppMethod_t GetGlobalOperator(TCppScope_t scope, const std::string& lc,

--- a/src/interop/cpp_cppjit.h
+++ b/src/interop/cpp_cppjit.h
@@ -94,7 +94,7 @@ TCppType_t GetType(const std::string& name, bool enable_slow_lookup = false);
 RPY_EXPORTED
 bool AppendTypesSlow(const std::string& name,
                      std::vector<Cpp::TemplateArgInfo>& types,
-                     cppjit::interop::TCppScope_t parent = nullptr);
+                     TCppScope_t parent = nullptr);
 RPY_EXPORTED
 TCppType_t GetComplexType(const std::string& element_type);
 RPY_EXPORTED
@@ -227,7 +227,7 @@ void GetAllCppNames(TCppScope_t scope, std::set<std::string>& cppnames);
 
 // namespace reflection information ------------------------------------------
 RPY_EXPORTED
-std::vector<cppjit::interop::TCppScope_t> GetUsingNamespaces(TCppScope_t);
+std::vector<TCppScope_t> GetUsingNamespaces(TCppScope_t);
 
 // class reflection information ----------------------------------------------
 RPY_EXPORTED
@@ -325,8 +325,7 @@ RPY_EXPORTED
 TCppMethod_t GetMethodTemplate(TCppScope_t scope, const std::string& name,
                                const std::string& proto);
 RPY_EXPORTED
-void GetClassOperators(cppjit::interop::TCppScope_t klass,
-                       const std::string& opname,
+void GetClassOperators(TCppScope_t klass, const std::string& opname,
                        std::vector<TCppMethod_t>& operators);
 RPY_EXPORTED
 TCppMethod_t GetGlobalOperator(TCppScope_t scope, const std::string& lc,


### PR DESCRIPTION
The interop namespace is trivially accessible from cpyrt, and all the extra qualification blaots the code and reduces readability. This patch improves that. Also fix a faulty find+replace case in a comment (`Cpycppjit`)