### PR TITLE
[WIP] On demand analyze for allocation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,8 @@ include(GNUInstallDirs)
 # This option won't make a lot of sense since we only ship the shared library in site-packages
 # Perhaps this should permanently be OFF and users can build their own CppInterOp if they want to run the tests?
 option(CPPJIT_ENABLE_CPPINTEROP_TESTS "enable CppInterOp tests" OFF)
-set(CPPINTEROP_GIT_REPOSITORY "https://github.com/compiler-research/CppInterOp.git" CACHE STRING "")
-set(CPPINTEROP_GIT_TAG "8d624c621a4b95e36ff73ac708c85a768287478f" CACHE STRING "")
+set(CPPINTEROP_GIT_REPOSITORY "https://github.com/keremsahn/CppInterOp.git" CACHE STRING "")
+set(CPPINTEROP_GIT_TAG "attr-design" CACHE STRING "")
 set(CPPINTEROP_SOURCE_DIR "" CACHE PATH
     "Override default CppInterOp built by ExternalProject_Add, with a path to local CppInterOp source")
 

--- a/python/cppjit/__init__.py
+++ b/python/cppjit/__init__.py
@@ -48,6 +48,7 @@ __all__ = [
     "add_library_path",  # add a path to search for libraries
     "add_autoload_map",  # explicitly include an autoload map
     "set_debug",  # enable/disable debug output
+    "use_alloc_analyzer",  # enable/disable memory ownership analyzer
 ]
 
 import ctypes
@@ -395,6 +396,11 @@ def add_autoload_map(fname):
 def set_debug(enable=True):
     """Enable/disable debug output."""
     gbl.Cpp.EnableDebugOutput(enable)
+
+
+def use_alloc_analyzer(enable=True):
+    """Enable/disable memory ownership analyzer"""
+    _backend.UseAllocAnalyzer(enable)
 
 
 def _get_name(tt):

--- a/src/cpyrt/CPPMethod.cxx
+++ b/src/cpyrt/CPPMethod.cxx
@@ -753,6 +753,14 @@ PyObject* cpyrt::CPPMethod::GetArgDefault(int iarg, bool silent) {
 bool cpyrt::CPPMethod::IsConst() { return interop::IsConstMethod(GetMethod()); }
 
 //----------------------------------------------------------------------------
+interop::AllocType cpyrt::CPPMethod::GetAllocBehaviour() {
+  if (fAllocType.has_value())
+    return *fAllocType;
+  interop::AllocType attrResult = interop::IsAllocator(GetMethod());
+  fAllocType = attrResult;
+  return attrResult;
+}
+//----------------------------------------------------------------------------
 PyObject* cpyrt::CPPMethod::GetScopeProxy() {
   // Get or build the scope of this method.
   return CreateScopeProxy(fScope);

--- a/src/cpyrt/CPPMethod.cxx
+++ b/src/cpyrt/CPPMethod.cxx
@@ -34,6 +34,7 @@ extern PyObject* gBusException;
 extern PyObject* gSegvException;
 extern PyObject* gIllException;
 extern PyObject* gAbrtException;
+extern bool gUseAllocAnalyzer;
 } // namespace cppjit::cpyrt
 
 //- public helper ------------------------------------------------------------
@@ -757,6 +758,11 @@ interop::AllocType cpyrt::CPPMethod::GetAllocBehaviour() {
   if (fAllocType.has_value())
     return *fAllocType;
   interop::AllocType attrResult = interop::IsAllocator(GetMethod());
+  if (attrResult == interop::AllocType::Unknown && gUseAllocAnalyzer) {
+    interop::AllocType analyzeResult = interop::GetAllocType(GetMethod());
+    fAllocType = analyzeResult;
+    return analyzeResult;
+  }
   fAllocType = attrResult;
   return attrResult;
 }

--- a/src/cpyrt/CPPMethod.h
+++ b/src/cpyrt/CPPMethod.h
@@ -5,6 +5,7 @@
 #include "PyCallable.h"
 
 // Standard
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -62,6 +63,7 @@ public:
   PyObject* GetCoVarNames() override;
   PyObject* GetArgDefault(int iarg, bool silent = true) override;
   bool IsConst() override;
+  cppjit::interop::AllocType GetAllocBehaviour() override;
 
   PyObject* GetScopeProxy() override;
   interop::TCppFuncAddr_t GetFunctionAddress() override;
@@ -116,6 +118,7 @@ private:
 protected:
   // cached value that doubles as initialized flag (uninitialized if -1)
   int fArgsRequired;
+  std::optional<cppjit::interop::AllocType> fAllocType;
 };
 
 } // namespace cppjit::cpyrt

--- a/src/cpyrt/CPPOverload.cxx
+++ b/src/cpyrt/CPPOverload.cxx
@@ -155,6 +155,12 @@ static inline PyObject* HandleReturn(CPPOverload* pymeth, CPPInstance* im_self,
     CPPInstance* cppres =
         (CPPInstance*)(CPPInstance_Check(result) ? result : nullptr);
 
+    interop::AllocType AT =
+        pymeth->fMethodInfo->fMethods[0]->GetAllocBehaviour();
+    if (AT != interop::AllocType::None && AT != interop::AllocType::Null &&
+        AT != interop::AllocType::Unknown)
+      pymeth->fMethodInfo->fFlags |= CallContext::kIsCreator;
+
     // if this method creates new objects, always take ownership
     if (IsCreator(pymeth->fMethodInfo->fFlags)) {
 

--- a/src/cpyrt/PyCallable.h
+++ b/src/cpyrt/PyCallable.h
@@ -37,6 +37,9 @@ public:
   virtual PyObject* GetCoVarNames() = 0;
   virtual PyObject* GetArgDefault(int /* iarg */, bool silent = true) = 0;
   virtual bool IsConst() { return false; }
+  virtual cppjit::interop::AllocType GetAllocBehaviour() {
+    return cppjit::interop::AllocType::None;
+  }
 
   virtual PyObject* GetScopeProxy() = 0;
   virtual interop::TCppFuncAddr_t GetFunctionAddress() = 0;

--- a/src/cpyrt/cpyrtModule.cxx
+++ b/src/cpyrt/cpyrtModule.cxx
@@ -279,6 +279,7 @@ PyObject* gAbrtException = nullptr;
 std::unordered_set<interop::TCppScope_t> gPinnedTypes;
 std::ostringstream gCapturedError;
 std::streambuf* gOldErrorBuffer = nullptr;
+bool gUseAllocAnalyzer = false;
 
 std::unordered_map<std::string, std::vector<PyObject*>>& pythonizations() {
   static std::unordered_map<std::string, std::vector<PyObject*>> pyzMap;
@@ -1012,6 +1013,20 @@ static PyObject* EndCaptureStderr(PyObject*, PyObject*) {
 
   return Py_BuildValue("s", capturedError.c_str());
 }
+
+//----------------------------------------------------------------------------
+static PyObject* UseAllocAnalyzer(PyObject*, PyObject* args) {
+  // Set allocation-analyzer policy, disabled by default
+  // Usage: enabling ->SetUseAllocAnalyzer(True) / SetUseAllocAnalyzer(1)
+  // disabling ->SetUseAllocAnalyzer(False) / SetUseAllocAnalyzer(0)
+  int enable = 0;
+  if (!PyArg_ParseTuple(args, const_cast<char*>("p"), &enable))
+    return nullptr;
+
+  gUseAllocAnalyzer = enable;
+
+  Py_RETURN_NONE;
+}
 } // unnamed namespace
 
 //- data -----------------------------------------------------------------------
@@ -1061,6 +1076,8 @@ static PyMethodDef gcpyrtMethods[] = {
      METH_NOARGS, (char*)"Begin capturing stderr to a in memory buffer."},
     {(char*)"_end_capture_stderr", (PyCFunction)EndCaptureStderr, METH_NOARGS,
      (char*)"End capturing stderr and returns the captured buffer."},
+    {(char*)"UseAllocAnalyzer", (PyCFunction)UseAllocAnalyzer, METH_VARARGS,
+     (char*)"Enable/disable memory-allocation analyzer."},
     {nullptr, nullptr, 0, nullptr}};
 
 struct module_state {

--- a/src/interop/cppjit_interop.h
+++ b/src/interop/cppjit_interop.h
@@ -300,6 +300,8 @@ RPY_EXPORTED
 bool IsConstMethod(TCppMethod_t);
 RPY_EXPORTED
 AllocType IsAllocator(TCppMethod_t);
+RPY_EXPORTED
+AllocType GetAllocType(TCppMethod_t);
 // Templated method/function reflection information
 // ------------------------------------
 RPY_EXPORTED

--- a/src/interop/cppjit_interop.h
+++ b/src/interop/cppjit_interop.h
@@ -44,6 +44,7 @@ typedef Cpp::FuncRef TCppMethod_t;
 typedef Cpp::InterpRef TInterp_t;
 typedef size_t TCppIndex_t;
 typedef void* TCppFuncAddr_t;
+typedef Cpp::AllocType AllocType;
 
 // direct interpreter access -------------------------------------------------
 RPY_EXPORTED
@@ -297,6 +298,8 @@ RPY_EXPORTED
 std::string GetDoxygenComment(TCppScope_t scope, bool strip_markers = true);
 RPY_EXPORTED
 bool IsConstMethod(TCppMethod_t);
+RPY_EXPORTED
+AllocType IsAllocator(TCppMethod_t);
 // Templated method/function reflection information
 // ------------------------------------
 RPY_EXPORTED

--- a/src/interop/interop_wrapper.cxx
+++ b/src/interop/interop_wrapper.cxx
@@ -1205,6 +1205,11 @@ interop::AllocType interop::IsAllocator(TCppMethod_t method) {
   return Cpp::IsAllocator(method);
 }
 
+interop::AllocType interop::GetAllocType(TCppMethod_t method) {
+  std::lock_guard<std::recursive_mutex> Lock(InterOpMutex);
+  return Cpp::GetAllocType(method);
+}
+
 std::string interop::GetMethodReturnTypeAsString(TCppMethod_t method) {
   std::lock_guard<std::recursive_mutex> Lock(InterOpMutex);
   return Cpp::GetTypeAsString(

--- a/src/interop/interop_wrapper.cxx
+++ b/src/interop/interop_wrapper.cxx
@@ -1200,6 +1200,11 @@ interop::TCppType_t interop::GetMethodReturnType(TCppMethod_t method) {
   return Cpp::GetFunctionReturnType(method);
 }
 
+interop::AllocType interop::IsAllocator(TCppMethod_t method) {
+  std::lock_guard<std::recursive_mutex> Lock(InterOpMutex);
+  return Cpp::IsAllocator(method);
+}
+
 std::string interop::GetMethodReturnTypeAsString(TCppMethod_t method) {
   std::lock_guard<std::recursive_mutex> Lock(InterOpMutex);
   return Cpp::GetTypeAsString(

--- a/test/Makefile
+++ b/test/Makefile
@@ -10,6 +10,7 @@ dictnames = advancedcpp \
             doc_helper \
             example01 \
             fragile \
+            memory_analysis \
             operators \
             overloads \
             pythonizables \

--- a/test/cpp/MemoryOwnership/MemOwnrship.apinotes
+++ b/test/cpp/MemoryOwnership/MemOwnrship.apinotes
@@ -1,0 +1,9 @@
+Name: MemOwnrship
+Functions:
+    - Name: memOwnAllocGlobal
+      SwiftReturnOwnership: cppAllocNew
+Tags:
+    - Name: memOwn
+      Methods:
+        - Name: memOwnAllocator
+          SwiftReturnOwnership: cppAllocNew

--- a/test/cpp/MemoryOwnership/memory_analysis_redecl.h
+++ b/test/cpp/MemoryOwnership/memory_analysis_redecl.h
@@ -1,0 +1,10 @@
+#ifndef MEMORY_ANALYSIS_REDECL_H
+#define MEMORY_ANALYSIS_REDECL_H
+#include "../memory_analysis.h"
+
+namespace memory {
+[[clang::annotate("cppAllocNew")]]
+memOwn* allocDefaultMemOwn();
+}
+
+#endif

--- a/test/cpp/MemoryOwnership/module.modulemap
+++ b/test/cpp/MemoryOwnership/module.modulemap
@@ -1,0 +1,1 @@
+module MemOwnrship { header "../memory_analysis.h" }

--- a/test/cpp/memory_analysis.cxx
+++ b/test/cpp/memory_analysis.cxx
@@ -1,0 +1,24 @@
+#include "memory_analysis.h"
+
+namespace memory {
+
+__attribute__((malloc)) memAnalysisKlass* mallocAttr() {
+  return new memAnalysisKlass;
+}
+
+__attribute__((ownership_returns(malloc))) memAnalysisKlass*
+ownershipReturnsAttr() {
+  return new memAnalysisKlass;
+}
+
+// Expected to not return ownership when analysis is off, and there is just
+// attr-check
+memAnalysisKlass* noAttr() { return new memAnalysisKlass; }
+
+memOwn* memOwnAllocGlobal() { return (memOwn*)malloc(sizeof(memOwn)); }
+
+memOwn* allocDefaultMemOwn() { return new memOwn; }
+
+memOwn* noAttrAlloc() { return new memOwn; }
+
+} // namespace memory

--- a/test/cpp/memory_analysis.h
+++ b/test/cpp/memory_analysis.h
@@ -1,0 +1,36 @@
+#ifndef MEMORY_ANALYSIS_H
+#define MEMORY_ANALYSIS_H
+
+#include <new>
+#include <stdlib.h>
+namespace memory {
+
+class memAnalysisKlass {
+public:
+  int val;
+};
+__attribute__((malloc)) memAnalysisKlass* mallocAttr();
+__attribute__((ownership_returns(malloc))) memAnalysisKlass*
+ownershipReturnsAttr();
+memAnalysisKlass* noAttr();
+
+struct memOwn {
+  int val;
+  memOwn(int value) : val(value) {}
+  memOwn() { val = 0; }
+  // Attribute injected by APINotes
+  static memOwn* memOwnAllocator(int x) { return new memOwn(x); }
+};
+
+// Attribute injected by APINotes
+memOwn* memOwnAllocGlobal();
+
+// Attribute injected by redeclaration
+memOwn* allocDefaultMemOwn();
+
+// No ownership attribute anywhere
+memOwn* noAttrAlloc();
+
+} // namespace memory
+
+#endif // MEMORY_ANALYSIS_H

--- a/test/cpp/memory_analysis.h
+++ b/test/cpp/memory_analysis.h
@@ -31,6 +31,8 @@ memOwn* allocDefaultMemOwn();
 // No ownership attribute anywhere
 memOwn* noAttrAlloc();
 
+inline memAnalysisKlass* allocAnalyzerOn() { return new memAnalysisKlass; }
+inline memAnalysisKlass* allocAnalyzerOff() { return new memAnalysisKlass; }
 } // namespace memory
 
 #endif // MEMORY_ANALYSIS_H

--- a/test/test_memoryanalysis.py
+++ b/test/test_memoryanalysis.py
@@ -1,0 +1,102 @@
+import os
+import subprocess
+import sys
+
+import py
+from pytest import mark
+from support import IS_CLING, setup_make
+
+currpath = py.path.local(__file__).dirpath()
+test_dct = str(currpath.join("cpp/memory_analysisDict"))
+
+FLAGS = "-fmodules -fimplicit-module-maps -fapinotes-modules"
+IN_CHILD = "-fapinotes-modules" in os.getenv("CPPINTEROP_EXTRA_INTERPRETER_ARGS", "")
+
+
+def setup_module(mod):
+    setup_make("memory_analysis")
+
+
+@mark.skipif(
+    IN_CHILD or IS_CLING,
+    reason="Cling asserts in collectModuleMaps when built with " + FLAGS,
+)
+def test00_driver():
+    env = os.environ.copy()
+    env["CPPINTEROP_EXTRA_INTERPRETER_ARGS"] = (
+        env.get("CPPINTEROP_EXTRA_INTERPRETER_ARGS", "") + " " + FLAGS
+    )
+    subprocess.check_call([sys.executable, "-m", "pytest", __file__], env=env)
+
+
+class TestMEMORYANALYSIS:
+    def setup_class(cls):
+        cls.test_dct = test_dct
+        import cppjit
+
+        cppjit.add_include_path(str(currpath.join("cpp", "MemoryOwnership")))
+        cppjit.include("../memory_analysis.h")
+        cppjit.include("memory_analysis_redecl.h")
+        cls.memory_analysis = cppjit.load_library(cls.test_dct + ".so")
+
+    def test01_malloc_attr(self):
+        import cppjit
+
+        obj = cppjit.gbl.memory.mallocAttr()
+        assert type(obj) == cppjit.gbl.memory.memAnalysisKlass
+        assert obj.__python_owns__
+
+    def test02_ownership_returns_attr(self):
+        import cppjit
+
+        obj = cppjit.gbl.memory.ownershipReturnsAttr()
+        assert type(obj) == cppjit.gbl.memory.memAnalysisKlass
+        assert obj.__python_owns__
+
+    def test03_no_attr(self):
+        import cppjit
+
+        obj = cppjit.gbl.memory.noAttr()
+        assert type(obj) == cppjit.gbl.memory.memAnalysisKlass
+        assert not obj.__python_owns__
+        obj.__python_owns__ = True
+
+    def test04_redecl_attr(self):
+        import cppjit
+
+        obj = cppjit.gbl.memory.allocDefaultMemOwn()
+        assert type(obj) == cppjit.gbl.memory.memOwn
+        assert obj.__python_owns__
+
+    def test05_redecl_no_attr(self):
+        import cppjit
+
+        obj = cppjit.gbl.memory.noAttrAlloc()
+        assert type(obj) == cppjit.gbl.memory.memOwn
+        assert not obj.__python_owns__
+        obj.__python_owns__ = True
+
+
+@mark.skipif(not IN_CHILD, reason="needs " + FLAGS)
+class TestMEMORYANALYSIS_APINOTES:
+    def setup_class(cls):
+        cls.test_dct = test_dct
+        import cppjit
+
+        cppjit.add_include_path(str(currpath.join("cpp", "MemoryOwnership")))
+        cppjit.include("../memory_analysis.h")
+        cls.memory_analysis = cppjit.load_library(cls.test_dct + ".so")
+
+    def test01_apinotes_attr_method(self):
+        import cppjit
+
+        obj = cppjit.gbl.memory.memOwn.memOwnAllocator(5)
+        assert type(obj) == cppjit.gbl.memory.memOwn
+        assert obj.__python_owns__
+
+    def test02_apinotes_attr_func(self):
+        import cppjit
+
+        obj = cppjit.gbl.memory.memOwnAllocGlobal()
+        assert type(obj) == cppjit.gbl.memory.memOwn
+        assert obj.__python_owns__

--- a/test/test_memoryanalysis.py
+++ b/test/test_memoryanalysis.py
@@ -76,6 +76,31 @@ class TestMEMORYANALYSIS:
         assert not obj.__python_owns__
         obj.__python_owns__ = True
 
+    def test06_analyzer_on(self):
+        import cppjit
+
+        cppjit.use_alloc_analyzer(True)
+        obj = cppjit.gbl.memory.allocAnalyzerOn()
+        assert obj.__python_owns__
+
+    def test07_analyzer_off(self):
+        import cppjit
+
+        cppjit.use_alloc_analyzer(False)
+        obj = cppjit.gbl.memory.allocAnalyzerOff()
+        assert not (obj.__python_owns__)
+
+    def test08_analyzer_off_but_cache(self):
+        import cppjit
+
+        cppjit.use_alloc_analyzer(True)
+        obj = cppjit.gbl.memory.allocAnalyzerOn()
+        assert obj.__python_owns__
+
+        cppjit.use_alloc_analyzer(False)
+        obj2 = cppjit.gbl.memory.allocAnalyzerOn()
+        assert obj2.__python_owns__
+
 
 @mark.skipif(not IN_CHILD, reason="needs " + FLAGS)
 class TestMEMORYANALYSIS_APINOTES:


### PR DESCRIPTION
Built upon #35 
Added wrapping for GetAllocType, and it is called if user sets gUseAllocAnalyze variable, which is disabled by default. Analyzer has lower priority compared to attribute check.

A detail: Analyzer caches the result, so once the function is called with gUseAllocAnalyze, the result stays, even though the flag is set to False laterly.
@aaronj0 @vgvassilev @Vipul-Cariappa 