### PR TITLE
Penalise void* arguments in overload priority as intended

### DIFF
--- a/src/cpyrt/CPPMethod.cxx
+++ b/src/cpyrt/CPPMethod.cxx
@@ -529,7 +529,14 @@ int cpyrt::CPPMethod::GetPriority() {
     // type:
     // interop::TCppType_t type = interop::GetMethodArgType(fMethod, iarg);
 
-    if (interop::IsBuiltin(aname)) {
+    // Not builtin and spelled "const void *", so match the compacted name.
+    std::string compact = aname;
+    compact.erase(std::remove(compact.begin(), compact.end(), ' '),
+                  compact.end());
+
+    if (compact.find("void*") != std::string::npos) {
+      priority -= 1000; // void*/void** shouldn't be too greedy
+    } else if (interop::IsBuiltin(aname)) {
       // complex type (note: double penalty: for complex and the template type)
       if (strstr(aname.c_str(), "std::complex"))
         priority -= 10; // prefer double, float, etc. over conversion
@@ -556,10 +563,6 @@ int cpyrt::CPPMethod::GetPriority() {
       // string/char types
       else if (strstr(aname.c_str(), "char") && aname[aname.size() - 1] != '*')
         priority += -60; // prefer (const) char* over char
-
-      // oddball
-      else if (strstr(aname.c_str(), "void*"))
-        priority -= 1000; // void*/void** shouldn't be too greedy
 
     } else {
       // This is a user-defined type (class, struct, enum, etc.).

--- a/test/test_overloads.py
+++ b/test/test_overloads.py
@@ -411,3 +411,32 @@ class TestOVERLOADS:
         ptr = cppjit.gbl.MyClass()
 
         raises(TypeError, cppjit.gbl.changePtr, ptr)
+
+    def test16_voidp_does_not_outrank_conversion(self):
+        """Verify that a const void* overload does not shadow a converting one."""
+
+        import cppjit
+
+        cppjit.cppdef("""
+        namespace VoidPPriority {
+        struct Handle {
+            void* data;
+            Handle() : data(nullptr) {}
+            Handle(void* p) : data(p) {}
+        };
+        struct ConstHandle {
+            const void* data;
+            ConstHandle() : data(nullptr) {}
+            ConstHandle(const void* p) : data(p) {}   // declared first on purpose
+            ConstHandle(Handle h) : data(h.data) {}
+        };
+        Handle make_handle() { return Handle((void*)0xABCD1234); }
+        bool kept_value(ConstHandle c) { return c.data == (const void*)0xABCD1234; }
+        }""")
+
+        ns = cppjit.gbl.VoidPPriority
+
+        # taking ConstHandle(const void*) would pass the proxy's address instead
+        h = ns.make_handle()
+        assert ns.kept_value(h)
+        assert ns.kept_value(ns.make_handle())


### PR DESCRIPTION
Based on the work from the compiler research forks: https://github.com/compiler-research/CPyCppyy/pull/225 and https://github.com/compiler-research/cppyy/pull/239
Migrated with AI

cc @conrade-ctc