### PR TITLE
Improve error reporting for method calls without a C++ object

### DIFF
--- a/src/cpyrt/CPPMethod.cxx
+++ b/src/cpyrt/CPPMethod.cxx
@@ -1058,7 +1058,8 @@ PyObject* cpyrt::CPPMethod::Call(CPPInstance*& self, cpyrt_PyArgs_t args,
 
   // validity check that should not fail
   if (!object) {
-    PyErr_SetString(PyExc_ReferenceError, "attempt to access a null-pointer");
+    PyErr_SetString(PyExc_ReferenceError, "no C++ object available");
+    ctxt->fFlags |= CallContext::kCppException;
     return nullptr;
   }
 

--- a/src/cpyrt/CPPOverload.cxx
+++ b/src/cpyrt/CPPOverload.cxx
@@ -624,7 +624,8 @@ static PyObject* mp_vectorcall(CPPOverload* pymeth, PyObject* const* args,
       return HandleReturn(pymeth, im_self, result);
 
     // fall through: python is dynamic, and so, the hashing isn't infallible
-    ctxt.fFlags &= ~CallContext::kAllowImplicit;
+    ctxt.fFlags &= ~(CallContext::kAllowImplicit | CallContext::kPyException |
+                     CallContext::kCppException);
     PyErr_Clear();
     ResetCallState(pymeth->fSelf, im_self);
   }

--- a/test/test_fragile.py
+++ b/test/test_fragile.py
@@ -761,6 +761,24 @@ class TestFRAGILE:
         for ns, val in [(cppjit.gbl, 42), (cppjit.gbl.ClassEnumNS, 37)]:
             assert ns.EnumTemplate[ns.ClassEnumA.A]().foo() == val
 
+    def test32_overloaded_method_error_with_null_object(self):
+        """Check exception type and message when method invoked on instance without C++ object"""
+
+        import cppjit
+        from cppjit import gbl
+
+        cppjit.cppdef(r"""\
+        using fragile::D;
+        D *something = new D;
+        D *nothing = nullptr;
+        """)
+
+        assert gbl.something.check() == gbl.something.check(0, 1)
+        with raises(ReferenceError, match=r"^no C\+\+ object available$"):
+            gbl.nothing.check()  # raises error
+        with raises(ReferenceError, match=r"^no C\+\+ object available$"):
+            gbl.nothing.check(0, 1)  # raises error
+
 
 class TestSIGNALS:
     def setup_class(cls):


### PR DESCRIPTION
Based on the work from the compiler research forks: https://github.com/compiler-research/CPyCppyy/pull/223 and https://github.com/compiler-research/cppyy/pull/237
Migrated with AI

cc @rybkine