### PR TITLE
[cpyrt] Reuse InitializerListConverter element converters

### DIFF
--- a/src/cpyrt/Converters.cxx
+++ b/src/cpyrt/Converters.cxx
@@ -3186,7 +3186,9 @@ bool cpyrt::InitializerListConverter::SetArg(PyObject* pyobject,
       PyObject* item = PySequence_GetItem(pyobject, i);
       bool convert_ok = false;
       if (item) {
-        Converter* converter = CreateConverter(fValueTypeName);
+        if (i >= fConverters.size())
+          fConverters.emplace_back(CreateConverter(fValueTypeName));
+        Converter* converter = fConverters[i];
         if (!converter) {
           if (CPPInstance_Check(item)) {
             // by convention, use byte copy
@@ -3208,10 +3210,8 @@ bool cpyrt::InitializerListConverter::SetArg(PyObject* pyobject,
                                  .c_str());
             entries += 1;
           }
-          if (memloc) {
+          if (memloc)
             convert_ok = converter->ToMemory(item, memloc);
-          }
-          fConverters.emplace_back(converter);
         }
 
         Py_DECREF(item);

--- a/test/test_leakcheck.py
+++ b/test/test_leakcheck.py
@@ -282,3 +282,21 @@ class TestLEAKCHECK:
         ns.leak_list = wrapped_list_by_value
 
         self.check_func(ns, "leak_list")
+
+    def test09_initializer_list_argument(self):
+        """Leak check of passing a list as an std::initializer_list argument"""
+
+        import cppjit
+
+        cppjit.cppdef("""\
+        namespace LeakCheck {
+            int sum_il(std::initializer_list<int> l) {
+                int s = 0;
+                for (auto i : l) s += i;
+                return s;
+            }
+        }""")
+
+        ns = cppjit.gbl.LeakCheck
+
+        self.check_func(ns, "sum_il", [1, 2, 3])


### PR DESCRIPTION
SetArg() created an element converter per call and appended it to fConverters, but Clear() frees only fBuffer, so the vector grew without bound across repeated std::initializer_list conversions. Create each element converter once and reuse it.

Upstreamed from the ROOT migration