### PR TITLE
[test] Skip the dictionary tests without a host toolchain

### DIFF
--- a/test/support.py
+++ b/test/support.py
@@ -1,10 +1,12 @@
 from __future__ import print_function
 
 import os
+import shutil
 import subprocess
 import sys
 
 import py
+import pytest
 
 try:
     import fcntl
@@ -13,10 +15,28 @@ except ImportError:  # Windows: no concurrent make workflow to serialize
 
 currpath = py.path.local(__file__).dirpath()
 
+_NO_TOOLCHAIN = "no make and C++ compiler to build the test dictionaries"
+# a build system that supplies the dictionaries itself sets CPPJIT_TEST_SKIP_MAKE
+_PREBUILT = bool(os.getenv("CPPJIT_TEST_SKIP_MAKE", False))
+# otherwise test/Makefile builds them with make and its default $(CXX)
+_HAS_TOOLCHAIN = bool(
+    shutil.which("make") and shutil.which(os.environ.get("CXX") or "g++")
+)
 
-def setup_make(targetname):
-    if os.getenv("CPPJIT_TEST_SKIP_MAKE", False):
+# for a test that loads a dictionary in a module whose other tests need none
+needs_dictionary = pytest.mark.skipif(
+    not (_PREBUILT or _HAS_TOOLCHAIN), reason=_NO_TOOLCHAIN
+)
+
+
+def setup_make(targetname, optional=False):
+    if _PREBUILT:
         return
+
+    if not _HAS_TOOLCHAIN:
+        if optional:
+            return
+        pytest.skip(_NO_TOOLCHAIN, allow_module_level=True)
 
     # several files share a dictionary, so workers race make for it; the lock
     # is per target to keep unrelated builds parallel

--- a/test/test_basic_api.py
+++ b/test/test_basic_api.py
@@ -3,7 +3,7 @@ import tempfile
 
 import py
 from pytest import raises
-from support import setup_make
+from support import needs_dictionary, setup_make
 
 # reuse the example01
 currpath = py.path.local(__file__).dirpath()
@@ -11,7 +11,8 @@ test_dct = str(currpath.join("cpp/example01Dict"))
 
 
 def setup_module(mod):
-    setup_make("example01")
+    # only test03_add_library_path loads the dictionary
+    setup_make("example01", optional=True)
 
 
 class TestBASICAPI:
@@ -39,6 +40,7 @@ class TestBASICAPI:
         assert cppjit.cppdef("namespace test02_NS { int x = 42; }")
         assert cppjit.gbl.test02_NS.x == 42
 
+    @needs_dictionary
     def test03_add_library_path(self):
         import cppjit
 


### PR DESCRIPTION
On a host with no make and no C++ compiler, every module that builds a test dictionary errors out in setup_make:

    FileNotFoundError: [Errno 2] No such file or directory: 'make'

This is a follow-up to #51. setup_make now checks for make and for make's $(CXX) first, and skips the module with a clear reason. A build system that sets CPPJIT_TEST_SKIP_MAKE is unaffected. In test_basic_api only test03_add_library_path loads a dictionary, so it gets a skip marker and the other API tests keep running.
