### PR TITLE
[cpyrt] Expose method const-qualification in func_overloads_types

### DIFF
--- a/src/cpyrt/CPPMethod.cxx
+++ b/src/cpyrt/CPPMethod.cxx
@@ -1165,6 +1165,11 @@ PyObject* cpyrt::CPPMethod::GetSignatureTypes() {
   PyDict_SetItem(signature_types_dict, cpyrt_PyText_FromString("input_types"),
                  parameter_types);
 
+  // Const-qualification of the method itself (always false for free
+  // functions and static methods).
+  PyDict_SetItem(signature_types_dict, cpyrt_PyText_FromString("is_const"),
+                 PyBool_FromLong(IsConst()));
+
   return signature_types_dict;
 }
 

--- a/src/cpyrt/CPPOverload.cxx
+++ b/src/cpyrt/CPPOverload.cxx
@@ -300,6 +300,9 @@ static PyObject* mp_func_overloads_names(CPPOverload* pymeth) {
  * ('float',), 'return_type': 'float'}, 'int ::foo(int a)': {'input_types':
  * ('int',), 'return_type': 'int'}, 'int ::foo(int a, float b)': {'input_types':
  * ('int', 'float'), 'return_type': 'int'}}
+ *
+ * Each overload's value dict also carries 'is_const': the method's own
+ * const-qualification (always False for free functions and static methods).
  */
 static PyObject* mp_func_overloads_types(CPPOverload* pymeth) {
 

--- a/test/test_overloads.py
+++ b/test/test_overloads.py
@@ -435,3 +435,43 @@ class TestOVERLOADS:
         h = ns.make_handle()
         assert ns.kept_value(h)
         assert ns.kept_value(ns.make_handle())
+
+    def test17_func_overloads_types_reports_constness(self):
+        """Verify func_overloads_types carries per-overload const-qualification."""
+
+        import cppjit
+
+        cppjit.cppdef("""
+        namespace OverloadConstness {
+        struct Probe {
+            int v = 0;
+            int get_const() const { return v; }
+            void set_nonconst(int x) { v = x; }
+            int mixed(int x) const { return x + v; }
+            double mixed(double x) { return x; }
+            static int static_fn(int x) { return x; }
+        };
+        }""")
+
+        cls = cppjit.gbl.OverloadConstness.Probe
+
+        def constness(name):
+            return {
+                sig: info["is_const"]
+                for sig, info in cls.__dict__[name].func_overloads_types.items()
+            }
+
+        assert constness("get_const") == {
+            "int OverloadConstness::Probe::get_const()": True
+        }
+        assert constness("set_nonconst") == {
+            "void OverloadConstness::Probe::set_nonconst(int x)": False
+        }
+        # constness is per overload, not per method name
+        assert constness("mixed") == {
+            "int OverloadConstness::Probe::mixed(int x)": True,
+            "double OverloadConstness::Probe::mixed(double x)": False,
+        }
+        assert constness("static_fn") == {
+            "static int OverloadConstness::Probe::static_fn(int x)": False
+        }


### PR DESCRIPTION
A caller could not tell whether a given overload was const-qualified. Each overload's entry in `func_overloads_types` now carries an `is_const` field. Free functions and static methods report `is_const` as `False`.
