### PR TITLE
[interop] Filter deleted functions from Python-visible overload sets

### DIFF
--- a/src/interop/interop_wrapper.cxx
+++ b/src/interop/interop_wrapper.cxx
@@ -1173,16 +1173,31 @@ ptrdiff_t interop::GetBaseOffset(TCppScope_t derived, TCppScope_t base,
 }
 
 // method/function reflection information ------------------------------------
+// A deleted overload is not callable, and leaving it in the set adds a
+// spurious conversion error to every failed-call report.
+static void
+remove_deleted_methods(std::vector<interop::TCppMethod_t>& methods) {
+  methods.erase(std::remove_if(methods.begin(), methods.end(),
+                               [](interop::TCppMethod_t m) {
+                                 return Cpp::IsFunctionDeleted(m);
+                               }),
+                methods.end());
+}
+
 void interop::GetClassMethods(TCppScope_t scope,
                               std::vector<interop::TCppMethod_t>& methods) {
   std::lock_guard<std::recursive_mutex> Lock(InterOpMutex);
   Cpp::GetClassMethods(scope, methods);
+  remove_deleted_methods(methods);
 }
 
 std::vector<interop::TCppMethod_t>
 interop::GetMethodsFromName(TCppScope_t scope, const std::string& name) {
   std::lock_guard<std::recursive_mutex> Lock(InterOpMutex);
-  return Cpp::GetFunctionsUsingName(scope, name);
+  std::vector<interop::TCppMethod_t> methods =
+      Cpp::GetFunctionsUsingName(scope, name);
+  remove_deleted_methods(methods);
+  return methods;
 }
 
 std::string interop::GetName(TCppScope_t method) {

--- a/test/test_crossinheritance.py
+++ b/test/test_crossinheritance.py
@@ -1675,7 +1675,6 @@ class TestCROSSINHERITANCE:
         c = C()
         assert c.func() == 3
 
-    @mark.xfail(reason="deriving from a ctor-less base does not raise TypeError")
     def test34_no_ctors_in_base(self):
         """Base classes with no constructors"""
 


### PR DESCRIPTION
A deleted function is not callable, yet it still entered the overload set and contributed a spurious conversion error to every failed-call report. That defeats SetDetailedException's rule that failures which are all C++ exceptions of one type are re-raised as that type.

Fixes tests in the ROOT migration as well as `test34_no_ctors_in_base` which expects TypeError for a class whose only constructors are deleted.