### PR TITLE
[ci] Build wheels for linux aarch64 and Intel mac

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -36,8 +36,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: ubuntu-24.04, label: manylinux-x86_64, arch: x86_64 }
-          - { os: macos-26,     label: macosx-arm64,     arch: arm64 }
+          - { os: ubuntu-24.04,     label: manylinux-x86_64,  arch: x86_64 }
+          - { os: ubuntu-24.04-arm, label: manylinux-aarch64, arch: aarch64 }
+          - { os: macos-26,         label: macosx-arm64,      arch: arm64 }
+          - { os: macos-26-intel,   label: macosx-x86_64,     arch: x86_64 }
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -53,7 +55,7 @@ jobs:
           version: '21.1.8'
           os: ${{ matrix.os }}
           arch: ${{ matrix.arch }}
-          ref: b760e4c171961786b7b20e2cc514302df5373eef
+          ref: 02f380b2e46746cd1c948c085894b8594a867fba
 
       - name: Stage the toolchain at /opt/llvm
         env:
@@ -152,7 +154,7 @@ jobs:
           version: '21.1.8'
           os: ubuntu-24.04
           arch: x86_64
-          ref: b760e4c171961786b7b20e2cc514302df5373eef
+          ref: 02f380b2e46746cd1c948c085894b8594a867fba
 
       - uses: actions/download-artifact@v8
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,8 @@ input = "python/cppjit/_version.py"
 # cp314t needs a free-threading audit first; cp315 joins at its release.
 build = ["cp312-*", "cp313-*", "cp314-*"]
 skip = ["*-musllinux*"]
+# one native runner per matrix row; no emulation
+archs = ["auto64"]
 build-verbosity = 1
 audit-requires = ["twine"]
 audit-command = "twine check {wheel}"
@@ -45,14 +47,13 @@ test-command = "python .github/wheel_smoke.py"
 test-environment = { PYTHONSAFEPATH = "1" }
 
 [tool.cibuildwheel.linux]
-archs = ["x86_64"]
 manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
 # /opt/llvm is staged on the runner by wheels.yml.
 container-engine = { name = "docker", create-args = ["--volume=/opt/llvm:/opt/llvm"], disable-host-mount = true }
 environment = { CMAKE_ARGS = "-DLLVM_DIR=/opt/llvm/lib/cmake/llvm -DClang_DIR=/opt/llvm/lib/cmake/clang" }
 
 [tool.cibuildwheel.macos]
-archs = ["arm64"]
 before-test = "brew install eigen boost && python -m pip install -r {project}/requirements.txt"
 test-command = "python .github/wheel_smoke.py && cd test && make -j$(sysctl -n hw.ncpu) PYTHON=python && CPPINTEROP_EXTRA_INTERPRETER_ARGS=-std=c++20 python -m pytest -ra"
 environment = { CMAKE_ARGS = "-DLLVM_DIR=/opt/llvm/lib/cmake/llvm -DClang_DIR=/opt/llvm/lib/cmake/clang", MACOSX_DEPLOYMENT_TARGET = "14.0" }


### PR DESCRIPTION
Will not work until the publish-recipe job on ci-workflows main is complete