### PR TITLE
[cpyrt] Do not decref a constructor result on Windows

### DIFF
--- a/src/cpyrt/CPPConstructor.h
+++ b/src/cpyrt/CPPConstructor.h
@@ -22,6 +22,7 @@ public:
 
 protected:
   bool InitExecutor_(Executor*&, CallContext* ctxt = nullptr) override;
+  bool ResultIsPyObject() const override { return false; }
 };
 
 // specialization for multiple inheritance disambiguation

--- a/src/cpyrt/CPPMethod.cxx
+++ b/src/cpyrt/CPPMethod.cxx
@@ -186,7 +186,8 @@ inline PyObject* cpyrt::CPPMethod::ExecuteFast(void* self, ptrdiff_t offset,
 // Windows, so instead leaves the error be
 #ifdef _WIN32
   if (PyErr_Occurred()) {
-    Py_XDECREF(result);
+    if (ResultIsPyObject())
+      Py_XDECREF(result);
     result = nullptr;
   }
 #endif

--- a/src/cpyrt/CPPMethod.h
+++ b/src/cpyrt/CPPMethod.h
@@ -91,6 +91,10 @@ protected:
 
   virtual bool InitExecutor_(Executor*&, CallContext* ctxt = nullptr);
 
+  // whether fExecutor's result is a real PyObject* (ConstructorExecutor
+  // returns the new object's address instead)
+  virtual bool ResultIsPyObject() const { return true; }
+
 private:
   void Copy_(const CPPMethod&);
   void Destroy_();


### PR DESCRIPTION
ExecuteFast() ends with a Windows-only block that drops the result when a Python exception is pending. It is shared by every CPPMethod subclass, including CPPConstructor, whose executor returns the address of the new C++ object cast to PyObject*; decref'ing that corrupts the heap. Ask the method whether its executor hands back a real PyObject* first. The object leaks instead, on the error path of a call that is already failing.