### PR TITLE
[cpyrt] Detect enum arguments by type in overload priority

### DIFF
--- a/src/cpyrt/CPPMethod.cxx
+++ b/src/cpyrt/CPPMethod.cxx
@@ -581,7 +581,9 @@ int cpyrt::CPPMethod::GetPriority() {
       if (scope)
         priority += static_cast<int>(interop::GetNumBasesLongestBranch(scope));
 
-      if (interop::IsEnumScope(scope))
+      // GetScope does not resolve enum names, so also detect enums by type
+      if (interop::IsEnumScope(scope) ||
+          interop::IsEnumType(interop::GetMethodArgType(fMethod, iarg)))
         priority -= 100;
 
       // a couple of special cases as explained above

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -1648,3 +1648,24 @@ class TestREGRESSION:
 
         with raises(TypeError):
             cppjit.gbl.std.vector[object()]
+
+    def test53_enum_arg_overload_priority(self):
+        """An integer argument prefers the integer overload over an enum one"""
+
+        import cppjit
+
+        cppjit.cppdef("""\
+        namespace EnumArgPriority {
+            enum Color { Red = 0, Green = 1, Blue = 2 };
+            int pick(Color)        { return 1; }
+            int pick(unsigned int) { return 2; }
+            int only_enum(Color c) { return 10 + (int)c; }
+        }""")
+
+        ns = cppjit.gbl.EnumArgPriority
+
+        # C++ has no implicit int -> enum conversion
+        assert ns.pick(2) == 2
+
+        # an enum parameter is only deprioritized, never unusable
+        assert ns.only_enum(2) == 12


### PR DESCRIPTION
GetPriority() deprioritizes enum arguments so that a competing integer overload wins, since C++ has no implicit int->enum conversion, but it detected them with IsEnumScope(GetScope(name)). GetScope does not resolve an enum name to a scope, so the penalty never applied. Query the argument type with IsEnumType as well, per the existing FIXME.