### PR TITLE
[ci] Add CppInterOp's clang22 aarch64 valgrind suppressions

### DIFF
--- a/.github/workflows/pr-nightly.yml
+++ b/.github/workflows/pr-nightly.yml
@@ -17,4 +17,7 @@ concurrency:
 jobs:
   nightly:
     if: ${{ github.event.label.name == 'test-nightly' }}
+    permissions:
+      contents: read
+      issues: write
     uses: ./.github/workflows/nightly.yml


### PR DESCRIPTION
From CppInterOp, required to keep the arm vg runs in the nightlies green 