### PR TITLE
[post-release] bump version to 0.1.0b1.dev0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![CI](https://github.com/compiler-research/cppjit/actions/workflows/ci.yml/badge.svg)](https://github.com/compiler-research/cppjit/actions/workflows/ci.yml)
 [![Nightlies](https://github.com/compiler-research/cppjit/actions/workflows/nightly.yml/badge.svg)](https://github.com/compiler-research/cppjit/actions/workflows/nightly.yml)
 [![Wheels](https://github.com/compiler-research/cppjit/actions/workflows/wheels.yml/badge.svg)](https://github.com/compiler-research/cppjit/actions/workflows/wheels.yml)
-[![Python](https://img.shields.io/badge/python-3.12%20%7C%203.13%20%7C%203.14-blue)](https://github.com/compiler-research/cppjit)
+[![PyPI](https://img.shields.io/pypi/v/cppjit)](https://pypi.org/project/cppjit/)
+[![Python](https://img.shields.io/pypi/pyversions/cppjit)](https://pypi.org/project/cppjit/)
 [![License](https://img.shields.io/badge/license-BSD--3--Clause--LBNL-green)](https://spdx.org/licenses/BSD-3-Clause-LBNL.html)
 
 cppjit embeds an interactive C++ JIT compiler in Python: write or import

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,61 +1,42 @@
-# cppjit 0.1.0a1 Release Notes
+# cppjit 0.1.0b1 Release Notes
 
-This document contains the release notes for cppjit 0.1.0a1, an
+This document contains the release notes for cppjit 0.1.0b1, an
 automatic Python-C++ interoperability layer and bindings generator
-built on [CppInterOp](https://github.com/compiler-research/CppInterOp)
-and the [LLVM](https://llvm.org) compiler infrastructure.
+built on CppInterOp and the LLVM compiler infrastructure. If you are
+reading this file from a git checkout, it describes the *next* release,
+not the current one. The notes of previously released versions are
+archived on the
+[releases page](https://github.com/compiler-research/cppjit/releases).
 
 This release supports Python 3.12-3.14 and LLVM 21-22.
 
 ## Highlights
 
-- cppjit 0.1.0a1 is the first prerelease of cppjit, the successor of
-  [cppyy](https://github.com/wlav/cppyy) rebuilt on CppInterOp and the
-  clang-repl C++ interpreter in LLVM.
-- The release installs from PyPI with `pip install cppjit` and ships
-  wheels for Linux x86_64/aarch64 and macOS arm64/x86_64 on Python
-  3.12-3.14, built with the LLVM 21 toolchain.
-- This first prerelease establishes the build system, test, and
-  packaging infrastructure of the new monorepo, with planned
-  improvements, documentation, and benchmarks in the next beta
-  release.
+- ...
 
-## Changes from cppyy
+## New features
 
-The user-facing Python layer is mostly unchanged from cppyy: `cppdef`,
-`include`, `gbl`, and the pythonization machinery work as before. The
-changes are in the compiler layer underneath:
+- ...
 
-- New backend:
-  [CppInterOp](https://github.com/compiler-research/CppInterOp) and
-  the clang-repl incremental compiler replace Cling and its patched
-  LLVM. clang-repl is the upstreamed evolution of Cling, so cppjit
-  builds against stock LLVM releases with no custom patches.
-- Compiler-derived bindings: string-based type lookups give way to
-  opaque handles on the Clang AST, and type conversion and overload
-  resolution follow Clang's own rules.
-- One package: the cppyy, CPyCppyy, and cppyy-backend distribution
-  stack is consolidated into a single package and repository, built
-  with scikit-build-core and published to PyPI through trusted
-  publishing.
-- Supported platforms: CPython 3.12-3.14 on Linux x86_64/aarch64 and
-  macOS arm64/x86_64. cppyy's PyPy support is not carried over.
-  Windows is not supported with this release but is a planned future
-  development
-  ([#89](https://github.com/compiler-research/cppjit/issues/89)).
+## Deprecated features
+
+- ...
+
+## Backwards incompatible changes
+
+- ...
+
+## Other changes
+
+- ...
 
 ## Contributors
 
 Special thanks to everyone who contributed to this release:
 
-- Aaron Jomy
-- Emery Conrad
-- Grigori Rybkine
-- Jonas Rembser
-- Kerem Şahin
-- Vassil Vassilev
-- Vipul Cariappa
-- Wim Lavrijsen
+- ...
 
-And all past contributors to the now-archived compiler-research
-forks of cppyy, CPyCppyy and cppyy-backend.
+<!-- Contributors since the previous release, with commit counts, in
+alphabetical order:
+ git log --pretty='%an' v0.1.0a1..HEAD | sort | uniq -c
+-->

--- a/python/cppjit/_version.py
+++ b/python/cppjit/_version.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.0a1"
+__version__ = "0.1.0b1.dev0"


### PR DESCRIPTION
Reset the releasenotes and add the new PyPI project banners