### PR TITLE
[test] Record and assert thread failures in the overload-reuse test

### DIFF
--- a/test/test_concurrent.py
+++ b/test/test_concurrent.py
@@ -251,10 +251,17 @@ class TestCONCURRENT:
             virtual void set_something(std::map<std::string, std::string>, std::string) {}
         }; }""")
 
+        # A thread that dies with an exception only warns; collect and
+        # assert instead, so conversion clashes actually fail the test.
+        failures = []
+
         def test():
-            o = {"a": "b"}  # causes a temporary to be created
-            simulation = cppjit.gbl.CPPOverloadReuse.Simulation1()
-            simulation.set_something(o, ".")
+            try:
+                o = {"a": "b"}  # causes a temporary to be created
+                simulation = cppjit.gbl.CPPOverloadReuse.Simulation1()
+                simulation.set_something(o, ".")
+            except Exception as e:
+                failures.append(e)
 
         threads = [threading.Thread(target=test) for i in range(0, 100)]
 
@@ -263,6 +270,10 @@ class TestCONCURRENT:
 
         for t in threads:
             t.join()
+
+        assert not failures, (
+            f"{len(failures)} of {len(threads)} threads failed: {failures[0]}"
+        )
 
     def test07_overload_reuse_in_threads_wo_gil(self):
         """Threads reuse overload objects; check for clashes if no GIL"""


### PR DESCRIPTION
As seen on the CI on mac platforms:

```
[93](https://github.com/compiler-research/cppjit/actions/runs/34221110946/job/102044181415#step:8:702)
    =============================== warnings summary ===============================
    test/test_concurrent.py::TestCONCURRENT::test06_overload_reuse_in_threads
      /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/_pytest/threadexception.py:58: PytestUnhandledThreadExceptionWarning: Exception in thread Thread-104 (test)
      
      Traceback (most recent call last):
        File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
          self.run()
        File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1012, in run
          self._target(*self._args, **self._kwargs)
        File "/Users/runner/work/cppjit/cppjit/test/test_concurrent.py", line 257, in test
          simulation.set_something(o, ".")
      TypeError: void CPPOverloadReuse::Simulation1::set_something(std::map<std::string, std::string>, std::string) =>
          TypeError: could not convert argument 1: [InstanceConverter]
      
      Enable tracemalloc to get traceback where the object was allocated.
      See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
        warnings.warn(pytest.PytestUnhandledThreadExceptionWarning(msg))
```

the threads here failed but the test never checked if they raised an exception. This should expose the real failures