### PR TITLE
[cpyrt] Import the cppjit module when gThisModule is null

### DIFF
--- a/src/cpyrt/API.cxx
+++ b/src/cpyrt/API.cxx
@@ -59,9 +59,15 @@ static bool Initialize() {
                 << std::endl;
       return false;
     }
+  }
 
-    // force loading of the cppjit module
-    PyRun_SimpleString(const_cast<char*>("import cppjit"));
+  // Importing the extension module is what runs the cpyrt initialization
+  // that sets gThisModule.
+  if (!cpyrt::gThisModule) {
+    PyObject* cppjitmod = PyImport_ImportModule("cppjit");
+    if (!cppjitmod)
+      return false;
+    Py_DECREF(cppjitmod);
   }
 
   if (!gMainDict) {


### PR DESCRIPTION
Entering through the public API (Instance_FromVoidPtr) without importing cppjit leaves gThisModule null. With Python already initialized, Initialize() skipped the import and reported success anyway, so CreateScopeProxy() dereferenced null. Import the extension module whenever gThisModule is null.